### PR TITLE
fonts from texlive and ms

### DIFF
--- a/docker/apt.txt
+++ b/docker/apt.txt
@@ -1,7 +1,11 @@
 # # Dependencies for Navteca OSS JupyterHub
 fuse
 
-# # # Dependencies for nbconvert and myst
+# # Fonts
+texlive-fonts-recommended
+ttf-mscorefonts-installer
+
+# # Dependencies for nbconvert and myst
 # # LaTeX tools
 # texlive-xetex
 # texlive-plain-generic


### PR DESCRIPTION
Only minimal fonts were present on the image. Check what this does to image size before merging.

A problem will be the fonts cache that lives in `~/.cache/matplotlib`.