### PR TITLE
Update website on push rather than pull_request

### DIFF
--- a/.github/workflows/update-website.yaml
+++ b/.github/workflows/update-website.yaml
@@ -1,13 +1,10 @@
 name: Update website
 on:
-  pull_request:
+  push:
     branches:
       - main
-    types:
-      - closed
 jobs:
   call:
-    if: ${{ github.event.pull_request.merged }}
     uses: ./.github/workflows/build-website.yaml
   deploy:
     needs: call


### PR DESCRIPTION
The pull_request does not run on the protected branch, so deployment from a workflow fails because of environment protection rules.

Branch protection rules make pull requests the only source of pushes to main, so this change is a simpler way of getting the same result.