### PR TITLE
updates to oci_data_visualization_part2

### DIFF
--- a/container/conda-lock.yml
+++ b/container/conda-lock.yml
@@ -15,17 +15,17 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: 8cd89b2dbc8ae673cdcfc98c42118e696050760b04ae967c15c1774616d474bd
-    osx-64: d768a05b2c54e5842440eb012ac661562f5ca8b232d0287339fdadf3415150fa
-    linux-aarch64: d2565d3eec2fedc0a7dafc6fed483ef750d29a3cb64664ae4d120d81b98f8f65
-    osx-arm64: 647588cbc324d4fb7a7c91b050bd8e846006348ce96122142fbd7177bdaa3089
+    linux-64: f2a98ab1d31ecc4de45403367fa2761a3ad70a3d5710e92f771aad8471240fad
+    osx-64: 73f6a0bd59f4565c11d7f6f4b223afd09f01af68526ce8bba534becf5327554d
+    linux-aarch64: 2dc274bd072a61a02c883d7a8efc9407465191e4af834ed1aba4da452b4a46a5
+    osx-arm64: ab56c12d7d89a9cc168f9761596d9aff6d1bb9ab3f2cd06e4a0578d3035a7193
   channels:
   - url: conda-forge
     used_env_vars: []
   platforms:
   - linux-64
-  - osx-64
   - linux-aarch64
+  - osx-64
   - osx-arm64
   sources:
   - ../pyproject.toml
@@ -316,7 +316,7 @@ package:
   category: tools
   optional: true
 - name: alembic
-  version: 1.18.4
+  version: 1.18.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -325,58 +325,58 @@ package:
     sqlalchemy: '>=1.4.23'
     tomli: ''
     typing_extensions: '>=4.12'
-  url: https://conda.anaconda.org/conda-forge/noarch/alembic-1.18.4-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/alembic-1.18.5-pyhcf101f3_0.conda
   hash:
-    md5: c45fa7cf996b766cb63eadf3c3e6408a
-    sha256: 83fc576dbcd59427f55be9623e1b101a1607ed9b4dc8633d86ada30c6ec1cf1d
+    md5: 5e2f9d485f398f312a6b0f17e11d9c6f
+    sha256: 3d523e517cb0b2a3cbfaf56a6f0d897062ab741eab1a8a4b3cc415a42bdef20a
   category: container
   optional: true
 - name: alembic
-  version: 1.18.4
+  version: 1.18.5
   manager: conda
   platform: linux-aarch64
   dependencies:
     mako: ''
-    python: ''
+    python: '>=3.10'
     sqlalchemy: '>=1.4.23'
     tomli: ''
     typing_extensions: '>=4.12'
-  url: https://conda.anaconda.org/conda-forge/noarch/alembic-1.18.4-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/alembic-1.18.5-pyhcf101f3_0.conda
   hash:
-    md5: c45fa7cf996b766cb63eadf3c3e6408a
-    sha256: 83fc576dbcd59427f55be9623e1b101a1607ed9b4dc8633d86ada30c6ec1cf1d
+    md5: 5e2f9d485f398f312a6b0f17e11d9c6f
+    sha256: 3d523e517cb0b2a3cbfaf56a6f0d897062ab741eab1a8a4b3cc415a42bdef20a
   category: container
   optional: true
 - name: alembic
-  version: 1.18.4
+  version: 1.18.5
   manager: conda
   platform: osx-64
   dependencies:
     mako: ''
-    python: ''
+    python: '>=3.10'
     sqlalchemy: '>=1.4.23'
     tomli: ''
     typing_extensions: '>=4.12'
-  url: https://conda.anaconda.org/conda-forge/noarch/alembic-1.18.4-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/alembic-1.18.5-pyhcf101f3_0.conda
   hash:
-    md5: c45fa7cf996b766cb63eadf3c3e6408a
-    sha256: 83fc576dbcd59427f55be9623e1b101a1607ed9b4dc8633d86ada30c6ec1cf1d
+    md5: 5e2f9d485f398f312a6b0f17e11d9c6f
+    sha256: 3d523e517cb0b2a3cbfaf56a6f0d897062ab741eab1a8a4b3cc415a42bdef20a
   category: container
   optional: true
 - name: alembic
-  version: 1.18.4
+  version: 1.18.5
   manager: conda
   platform: osx-arm64
   dependencies:
     mako: ''
-    python: ''
+    python: '>=3.10'
     sqlalchemy: '>=1.4.23'
     tomli: ''
     typing_extensions: '>=4.12'
-  url: https://conda.anaconda.org/conda-forge/noarch/alembic-1.18.4-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/alembic-1.18.5-pyhcf101f3_0.conda
   hash:
-    md5: c45fa7cf996b766cb63eadf3c3e6408a
-    sha256: 83fc576dbcd59427f55be9623e1b101a1607ed9b4dc8633d86ada30c6ec1cf1d
+    md5: 5e2f9d485f398f312a6b0f17e11d9c6f
+    sha256: 3d523e517cb0b2a3cbfaf56a6f0d897062ab741eab1a8a4b3cc415a42bdef20a
   category: container
   optional: true
 - name: annotated-types
@@ -484,7 +484,7 @@ package:
   category: tools
   optional: true
 - name: anyio
-  version: 4.14.0
+  version: 4.14.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -492,14 +492,14 @@ package:
     idna: '>=2.8'
     python: ''
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: e679dcf15f30bf6e3f1bb3ba69bcf29c
-    sha256: dc9c18c3766f82d88dbe6b25d25580e14fcc94d3c84524f610b713c2a72dd038
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: container
   optional: true
 - name: anyio
-  version: 4.14.0
+  version: 4.14.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -507,100 +507,100 @@ package:
     idna: '>=2.8'
     python: ''
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: e679dcf15f30bf6e3f1bb3ba69bcf29c
-    sha256: dc9c18c3766f82d88dbe6b25d25580e14fcc94d3c84524f610b713c2a72dd038
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: jupyter
   optional: true
 - name: anyio
-  version: 4.14.0
+  version: 4.14.1
   manager: conda
   platform: linux-aarch64
   dependencies:
     exceptiongroup: '>=1.0.2'
     idna: '>=2.8'
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: e679dcf15f30bf6e3f1bb3ba69bcf29c
-    sha256: dc9c18c3766f82d88dbe6b25d25580e14fcc94d3c84524f610b713c2a72dd038
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: container
   optional: true
 - name: anyio
-  version: 4.14.0
+  version: 4.14.1
   manager: conda
   platform: linux-aarch64
   dependencies:
     exceptiongroup: '>=1.0.2'
     idna: '>=2.8'
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: e679dcf15f30bf6e3f1bb3ba69bcf29c
-    sha256: dc9c18c3766f82d88dbe6b25d25580e14fcc94d3c84524f610b713c2a72dd038
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: jupyter
   optional: true
 - name: anyio
-  version: 4.14.0
+  version: 4.14.1
   manager: conda
   platform: osx-64
   dependencies:
     exceptiongroup: '>=1.0.2'
     idna: '>=2.8'
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: e679dcf15f30bf6e3f1bb3ba69bcf29c
-    sha256: dc9c18c3766f82d88dbe6b25d25580e14fcc94d3c84524f610b713c2a72dd038
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: container
   optional: true
 - name: anyio
-  version: 4.14.0
+  version: 4.14.1
   manager: conda
   platform: osx-64
   dependencies:
     exceptiongroup: '>=1.0.2'
     idna: '>=2.8'
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: e679dcf15f30bf6e3f1bb3ba69bcf29c
-    sha256: dc9c18c3766f82d88dbe6b25d25580e14fcc94d3c84524f610b713c2a72dd038
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: jupyter
   optional: true
 - name: anyio
-  version: 4.14.0
+  version: 4.14.1
   manager: conda
   platform: osx-arm64
   dependencies:
     exceptiongroup: '>=1.0.2'
     idna: '>=2.8'
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: e679dcf15f30bf6e3f1bb3ba69bcf29c
-    sha256: dc9c18c3766f82d88dbe6b25d25580e14fcc94d3c84524f610b713c2a72dd038
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: container
   optional: true
 - name: anyio
-  version: 4.14.0
+  version: 4.14.1
   manager: conda
   platform: osx-arm64
   dependencies:
     exceptiongroup: '>=1.0.2'
     idna: '>=2.8'
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: e679dcf15f30bf6e3f1bb3ba69bcf29c
-    sha256: dc9c18c3766f82d88dbe6b25d25580e14fcc94d3c84524f610b713c2a72dd038
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: jupyter
   optional: true
 - name: appdirs
@@ -990,7 +990,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     python-dateutil: '>=2.7.0'
     python-tzdata: ''
   url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
@@ -1004,7 +1004,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     python-dateutil: '>=2.7.0'
     python-tzdata: ''
   url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
@@ -1018,7 +1018,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     python-dateutil: '>=2.7.0'
     python-tzdata: ''
   url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
@@ -1032,7 +1032,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     python-dateutil: '>=2.7.0'
     python-tzdata: ''
   url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
@@ -1046,7 +1046,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     python-dateutil: '>=2.7.0'
     python-tzdata: ''
   url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
@@ -1060,7 +1060,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     python-dateutil: '>=2.7.0'
     python-tzdata: ''
   url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
@@ -1292,7 +1292,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
   hash:
@@ -1305,7 +1305,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
   hash:
@@ -1318,7 +1318,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
   hash:
@@ -1331,7 +1331,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
   hash:
@@ -1344,7 +1344,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
   hash:
@@ -1357,7 +1357,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
   hash:
@@ -1418,7 +1418,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
   hash:
     md5: c6b0543676ecb1fb2d7643941fe375f2
@@ -1430,7 +1430,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
   hash:
     md5: c6b0543676ecb1fb2d7643941fe375f2
@@ -1442,7 +1442,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
   hash:
     md5: c6b0543676ecb1fb2d7643941fe375f2
@@ -1454,7 +1454,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
   hash:
     md5: c6b0543676ecb1fb2d7643941fe375f2
@@ -1466,7 +1466,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
   hash:
     md5: c6b0543676ecb1fb2d7643941fe375f2
@@ -1478,7 +1478,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
   hash:
     md5: c6b0543676ecb1fb2d7643941fe375f2
@@ -1490,7 +1490,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
   hash:
     md5: c6b0543676ecb1fb2d7643941fe375f2
@@ -1502,7 +1502,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
   hash:
     md5: c6b0543676ecb1fb2d7643941fe375f2
@@ -1514,7 +1514,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
   hash:
     md5: c6b0543676ecb1fb2d7643941fe375f2
@@ -1526,7 +1526,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
   hash:
     md5: c6b0543676ecb1fb2d7643941fe375f2
@@ -1538,7 +1538,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
   hash:
     md5: c6b0543676ecb1fb2d7643941fe375f2
@@ -1550,7 +1550,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
   hash:
     md5: c6b0543676ecb1fb2d7643941fe375f2
@@ -1558,1211 +1558,1085 @@ package:
   category: tools
   optional: true
 - name: aws-c-auth
-  version: 0.10.3
+  version: 0.10.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
+    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.3-hd2277e8_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.1-ha62d5e7_3.conda
   hash:
-    md5: 9329dcd00c4d61aa49e516dddd784e91
-    sha256: 34238103e9b75a9ed0d8b01132551c2af4f9ae68ee2f81320a685ffb27731f6c
+    md5: 55eaf7066da1299d217ab32baedc7fa8
+    sha256: ccbf2cc4bea4aab6e071d67ecc2743197759f6df855787e7a5f57f7973f913a2
   category: container
   optional: true
 - name: aws-c-auth
-  version: 0.10.3
+  version: 0.10.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
+    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.3-hd2277e8_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.1-ha62d5e7_3.conda
   hash:
-    md5: 9329dcd00c4d61aa49e516dddd784e91
-    sha256: 34238103e9b75a9ed0d8b01132551c2af4f9ae68ee2f81320a685ffb27731f6c
+    md5: 55eaf7066da1299d217ab32baedc7fa8
+    sha256: ccbf2cc4bea4aab6e071d67ecc2743197759f6df855787e7a5f57f7973f913a2
   category: notebooks
   optional: true
 - name: aws-c-auth
-  version: 0.10.3
+  version: 0.10.1
   manager: conda
   platform: linux-aarch64
   dependencies:
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
+    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-auth-0.10.3-h5c394e5_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-auth-0.10.1-h32143b3_3.conda
   hash:
-    md5: ba4cb3df9e4a6013be09a6884070a69f
-    sha256: 08b1667546b6cadc722a5690632430eb793e0e92895115e6b55a83ef2e6a098e
+    md5: 28c1583cbbde708c93ee24767017fb21
+    sha256: cf3f41cb46f15b38a7991fb2c91d46a31b230c087af3db300d150b56aee2b2a7
   category: container
   optional: true
 - name: aws-c-auth
-  version: 0.10.3
+  version: 0.10.1
   manager: conda
   platform: linux-aarch64
   dependencies:
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
+    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-auth-0.10.3-h5c394e5_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-auth-0.10.1-h32143b3_3.conda
   hash:
-    md5: ba4cb3df9e4a6013be09a6884070a69f
-    sha256: 08b1667546b6cadc722a5690632430eb793e0e92895115e6b55a83ef2e6a098e
+    md5: 28c1583cbbde708c93ee24767017fb21
+    sha256: cf3f41cb46f15b38a7991fb2c91d46a31b230c087af3db300d150b56aee2b2a7
   category: notebooks
   optional: true
 - name: aws-c-auth
-  version: 0.10.3
+  version: 0.10.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.10.3-h0ebf9bf_3.conda
+    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.10.1-ha3f0692_3.conda
   hash:
-    md5: 5dcb2e3f244926bf09847f798ff1206a
-    sha256: ec12a2ad9d2979b20722ca387d8a782a925a135599de5a07cc0954f92f088718
+    md5: a86f1fa5a9479cf6a11df72083408626
+    sha256: 7cef042368d4e576b4f2cab16c964d989fba81a31b6bba9a70e8bb056d052775
   category: container
   optional: true
 - name: aws-c-auth
-  version: 0.10.3
+  version: 0.10.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.10.3-h0ebf9bf_3.conda
+    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.10.1-ha3f0692_3.conda
   hash:
-    md5: 5dcb2e3f244926bf09847f798ff1206a
-    sha256: ec12a2ad9d2979b20722ca387d8a782a925a135599de5a07cc0954f92f088718
+    md5: a86f1fa5a9479cf6a11df72083408626
+    sha256: 7cef042368d4e576b4f2cab16c964d989fba81a31b6bba9a70e8bb056d052775
   category: notebooks
   optional: true
 - name: aws-c-auth
-  version: 0.10.3
+  version: 0.10.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
+    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.1-ha7d4cc1_3.conda
   hash:
-    md5: 1fc365a60432d78b729d1468fce1b6c9
-    sha256: 623c4f69ce1e2eac92c209ef0e16e5f9ab8832232a749e3a272e11f1f46191c6
+    md5: 4fbd86a4d1efeb954b0d559d6717bd2b
+    sha256: ce023981f49a96074bc84d6249c7097b71c27e8d3bd750fc07c520579159521c
   category: container
   optional: true
 - name: aws-c-auth
-  version: 0.10.3
+  version: 0.10.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
+    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.1-ha7d4cc1_3.conda
   hash:
-    md5: 1fc365a60432d78b729d1468fce1b6c9
-    sha256: 623c4f69ce1e2eac92c209ef0e16e5f9ab8832232a749e3a272e11f1f46191c6
+    md5: 4fbd86a4d1efeb954b0d559d6717bd2b
+    sha256: ce023981f49a96074bc84d6249c7097b71c27e8d3bd750fc07c520579159521c
   category: notebooks
   optional: true
 - name: aws-c-cal
-  version: 0.9.14
+  version: 0.9.13
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    libgcc: '>=14'
+    openssl: '>=3.5.4,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
+  hash:
+    md5: 3c3d02681058c3d206b562b2e3bc337f
+    sha256: f21d648349a318f4ae457ea5403d542ba6c0e0343b8642038523dd612b2a5064
+  category: container
+  optional: true
+- name: aws-c-cal
+  version: 0.9.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    libgcc: '>=14'
+    openssl: '>=3.5.4,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
+  hash:
+    md5: 3c3d02681058c3d206b562b2e3bc337f
+    sha256: f21d648349a318f4ae457ea5403d542ba6c0e0343b8642038523dd612b2a5064
+  category: notebooks
+  optional: true
+- name: aws-c-cal
+  version: 0.9.13
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    libgcc: '>=14'
+    openssl: '>=3.5.4,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-cal-0.9.13-hc50a40c_1.conda
+  hash:
+    md5: 3c3c5433231502463d52abe1977885ad
+    sha256: 6273c7d5420eeb2450e0f2ce23d1d5a8da165a535ca8a7d2ad7005104d8697d8
+  category: container
+  optional: true
+- name: aws-c-cal
+  version: 0.9.13
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    libgcc: '>=14'
+    openssl: '>=3.5.4,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-cal-0.9.13-hc50a40c_1.conda
+  hash:
+    md5: 3c3c5433231502463d52abe1977885ad
+    sha256: 6273c7d5420eeb2450e0f2ce23d1d5a8da165a535ca8a7d2ad7005104d8697d8
+  category: notebooks
+  optional: true
+- name: aws-c-cal
+  version: 0.9.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.9.13-hea39f9f_1.conda
+  hash:
+    md5: cbf7be9e03e8b5e38ec60b6dbdf3a649
+    sha256: c085b749572ca7c137dfbf8a2a4fd505657f8f7f8a7b374d5f41bf4eb2dd9214
+  category: container
+  optional: true
+- name: aws-c-cal
+  version: 0.9.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.9.13-hea39f9f_1.conda
+  hash:
+    md5: cbf7be9e03e8b5e38ec60b6dbdf3a649
+    sha256: c085b749572ca7c137dfbf8a2a4fd505657f8f7f8a7b374d5f41bf4eb2dd9214
+  category: notebooks
+  optional: true
+- name: aws-c-cal
+  version: 0.9.13
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.9.13-h6ee9776_1.conda
+  hash:
+    md5: 8baab664c541d6f059e83423d9fc5e30
+    sha256: 13c42cb54619df0a1c3e5e5b0f7c8e575460b689084024fd23abeb443aac391b
+  category: container
+  optional: true
+- name: aws-c-cal
+  version: 0.9.13
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.9.13-h6ee9776_1.conda
+  hash:
+    md5: 8baab664c541d6f059e83423d9fc5e30
+    sha256: 13c42cb54619df0a1c3e5e5b0f7c8e575460b689084024fd23abeb443aac391b
+  category: notebooks
+  optional: true
+- name: aws-c-common
+  version: 0.12.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
+  hash:
+    md5: e36ad70a7e0b48f091ed6902f04c23b8
+    sha256: 926a5b9de0a586e88669d81de717c8dd3218c51ce55658e8a16af7e7fe87c833
+  category: container
+  optional: true
+- name: aws-c-common
+  version: 0.12.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
+  hash:
+    md5: e36ad70a7e0b48f091ed6902f04c23b8
+    sha256: 926a5b9de0a586e88669d81de717c8dd3218c51ce55658e8a16af7e7fe87c833
+  category: notebooks
+  optional: true
+- name: aws-c-common
+  version: 0.12.6
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-common-0.12.6-he30d5cf_0.conda
+  hash:
+    md5: f129515fce5e6cd2262ad2ba35ae2fe1
+    sha256: e4e9c47001c9a8bb9480c02a3e5c00d5494be71d952d1dbb9ea8506e97045fda
+  category: container
+  optional: true
+- name: aws-c-common
+  version: 0.12.6
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-common-0.12.6-he30d5cf_0.conda
+  hash:
+    md5: f129515fce5e6cd2262ad2ba35ae2fe1
+    sha256: e4e9c47001c9a8bb9480c02a3e5c00d5494be71d952d1dbb9ea8506e97045fda
+  category: notebooks
+  optional: true
+- name: aws-c-common
+  version: 0.12.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.12.6-h8616949_0.conda
+  hash:
+    md5: c7f2d588a6d50d170b343f3ae0b72e62
+    sha256: 66fb2710898bb3e25cb4af52ee88a0559dcde5e56e6bd09b31b98a346a89b2e3
+  category: container
+  optional: true
+- name: aws-c-common
+  version: 0.12.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.12.6-h8616949_0.conda
+  hash:
+    md5: c7f2d588a6d50d170b343f3ae0b72e62
+    sha256: 66fb2710898bb3e25cb4af52ee88a0559dcde5e56e6bd09b31b98a346a89b2e3
+  category: notebooks
+  optional: true
+- name: aws-c-common
+  version: 0.12.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.12.6-hc919400_0.conda
+  hash:
+    md5: b759f02a7fa946ea9fd9fb035422c848
+    sha256: cd3817c82470826167b1d8008485676862640cff65750c34062e6c20aeac419b
+  category: container
+  optional: true
+- name: aws-c-common
+  version: 0.12.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.12.6-hc919400_0.conda
+  hash:
+    md5: b759f02a7fa946ea9fd9fb035422c848
+    sha256: cd3817c82470826167b1d8008485676862640cff65750c34062e6c20aeac419b
+  category: notebooks
+  optional: true
+- name: aws-c-compression
+  version: 0.3.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
+  hash:
+    md5: f16f498641c9e05b645fe65902df661a
+    sha256: 1838bdc077b77168416801f4715335b65e9223f83641a2c28644f8acd8f9db0e
+  category: container
+  optional: true
+- name: aws-c-compression
+  version: 0.3.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
+  hash:
+    md5: f16f498641c9e05b645fe65902df661a
+    sha256: 1838bdc077b77168416801f4715335b65e9223f83641a2c28644f8acd8f9db0e
+  category: notebooks
+  optional: true
+- name: aws-c-compression
+  version: 0.3.2
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h6f28e42_0.conda
+  hash:
+    md5: ef3cfebe67bca3dfa00e8c1c470aac01
+    sha256: 835cdc4ad2e61354cb9f91068e6f8e5e90469fbbd2f2cc7e72bb6c16614bc81e
+  category: container
+  optional: true
+- name: aws-c-compression
+  version: 0.3.2
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h6f28e42_0.conda
+  hash:
+    md5: ef3cfebe67bca3dfa00e8c1c470aac01
+    sha256: 835cdc4ad2e61354cb9f91068e6f8e5e90469fbbd2f2cc7e72bb6c16614bc81e
+  category: notebooks
+  optional: true
+- name: aws-c-compression
+  version: 0.3.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.2-hb9ea233_0.conda
+  hash:
+    md5: da394e3dc9c78278c8bdbd3a81fdbdb2
+    sha256: 599eff2c7b6d2e4e2ed1594e330f5f4f06f0fbe21d20d53beb78e3443344555c
+  category: container
+  optional: true
+- name: aws-c-compression
+  version: 0.3.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.2-hb9ea233_0.conda
+  hash:
+    md5: da394e3dc9c78278c8bdbd3a81fdbdb2
+    sha256: 599eff2c7b6d2e4e2ed1594e330f5f4f06f0fbe21d20d53beb78e3443344555c
+  category: notebooks
+  optional: true
+- name: aws-c-compression
+  version: 0.3.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.2-h3e7f9b5_0.conda
+  hash:
+    md5: 6edccad10fc1c76a7a34b9c14efbeaa3
+    sha256: ce405171612acef0924a1ff9729d556db7936ad380a81a36325b7df5405a6214
+  category: container
+  optional: true
+- name: aws-c-compression
+  version: 0.3.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.2-h3e7f9b5_0.conda
+  hash:
+    md5: 6edccad10fc1c76a7a34b9c14efbeaa3
+    sha256: ce405171612acef0924a1ff9729d556db7936ad380a81a36325b7df5405a6214
+  category: notebooks
+  optional: true
+- name: aws-c-event-stream
+  version: 0.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+    aws-checksums: '>=0.2.10,<0.2.11.0a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.7.0-h9b893ba_0.conda
+  hash:
+    md5: 60076118b1579967748f0c9a2912de7c
+    sha256: 9692edaeaf90f7710b7ec49c7ca42961c59344dafa6fadbaec8c283b0606ca68
+  category: container
+  optional: true
+- name: aws-c-event-stream
+  version: 0.7.0
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+    aws-checksums: '>=0.2.10,<0.2.11.0a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-event-stream-0.7.0-h7ae2b9c_0.conda
+  hash:
+    md5: eda4f84526bce9ad439604c95ad572c5
+    sha256: 13eb6927006bc5963353475ea39608b3459653e5b75f48536b915d48a50ee44b
+  category: container
+  optional: true
+- name: aws-c-event-stream
+  version: 0.7.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+    aws-checksums: '>=0.2.10,<0.2.11.0a0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.7.0-ha9bd753_0.conda
+  hash:
+    md5: a7f76898deba16f0b70782ad3c0f841a
+    sha256: f8127169c450667c802ffe5cfc38eee2291ce253aa2b6bf244bc09d74e4edbac
+  category: container
+  optional: true
+- name: aws-c-event-stream
+  version: 0.7.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+    aws-checksums: '>=0.2.10,<0.2.11.0a0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.7.0-h351c84d_0.conda
+  hash:
+    md5: cb6d3b9905ffa47de2628e1ba9666c33
+    sha256: 454c02593d88246ac0fd4fc5e306147dd4f6c4866931c436ddeccdb37a70250f
+  category: container
+  optional: true
+- name: aws-c-http
+  version: 0.10.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-compression: '>=0.3.2,<0.3.3.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.13-h4bacb7b_0.conda
+  hash:
+    md5: 77f70a9ab785a146dbf66fba00131403
+    sha256: 38cfc8894db6729770ac18f900296c3f7c20f349a5586a8d8e1a62571fce61d5
+  category: container
+  optional: true
+- name: aws-c-http
+  version: 0.10.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-compression: '>=0.3.2,<0.3.3.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.13-h4bacb7b_0.conda
+  hash:
+    md5: 77f70a9ab785a146dbf66fba00131403
+    sha256: 38cfc8894db6729770ac18f900296c3f7c20f349a5586a8d8e1a62571fce61d5
+  category: notebooks
+  optional: true
+- name: aws-c-http
+  version: 0.10.13
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-compression: '>=0.3.2,<0.3.3.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-http-0.10.13-h8f13f89_0.conda
+  hash:
+    md5: 2058783f30a7ede1282bc83131bde9f0
+    sha256: 762da921c0d3cb9ffba6393be01bbee07ae5c309ba8c7e928b7efed3fb05870d
+  category: container
+  optional: true
+- name: aws-c-http
+  version: 0.10.13
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-compression: '>=0.3.2,<0.3.3.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-http-0.10.13-h8f13f89_0.conda
+  hash:
+    md5: 2058783f30a7ede1282bc83131bde9f0
+    sha256: 762da921c0d3cb9ffba6393be01bbee07ae5c309ba8c7e928b7efed3fb05870d
+  category: notebooks
+  optional: true
+- name: aws-c-http
+  version: 0.10.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-compression: '>=0.3.2,<0.3.3.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.10.13-h1037d30_0.conda
+  hash:
+    md5: 52af2e201214cbd7bc6282f01c535879
+    sha256: 5dd30efffb930499b30b0c0ad98cae9c62179143d07645e18823e04e50667d90
+  category: container
+  optional: true
+- name: aws-c-http
+  version: 0.10.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-compression: '>=0.3.2,<0.3.3.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.10.13-h1037d30_0.conda
+  hash:
+    md5: 52af2e201214cbd7bc6282f01c535879
+    sha256: 5dd30efffb930499b30b0c0ad98cae9c62179143d07645e18823e04e50667d90
+  category: notebooks
+  optional: true
+- name: aws-c-http
+  version: 0.10.13
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-compression: '>=0.3.2,<0.3.3.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.10.13-h95cdebe_0.conda
+  hash:
+    md5: fc4478bc51e76c5d26ea2c4f1e3ba366
+    sha256: 7a008a5a2f76256e841a8565b373a7dcfd2a439e5d9dbec320322468637f69e5
+  category: container
+  optional: true
+- name: aws-c-http
+  version: 0.10.13
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-compression: '>=0.3.2,<0.3.3.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.10.13-h95cdebe_0.conda
+  hash:
+    md5: fc4478bc51e76c5d26ea2c4f1e3ba366
+    sha256: 7a008a5a2f76256e841a8565b373a7dcfd2a439e5d9dbec320322468637f69e5
+  category: notebooks
+  optional: true
+- name: aws-c-io
+  version: 0.26.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    libgcc: '>=14'
+    s2n: '>=1.7.2,<1.7.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h692f434_1.conda
+  hash:
+    md5: 14260392d0b491c537b5e26e9a506fff
+    sha256: e3e33031d641864128ab11f9b8585ad5beb82fa988fe833bb0767dd01878a371
+  category: container
+  optional: true
+- name: aws-c-io
+  version: 0.26.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    libgcc: '>=14'
+    s2n: '>=1.7.2,<1.7.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h692f434_1.conda
+  hash:
+    md5: 14260392d0b491c537b5e26e9a506fff
+    sha256: e3e33031d641864128ab11f9b8585ad5beb82fa988fe833bb0767dd01878a371
+  category: notebooks
+  optional: true
+- name: aws-c-io
+  version: 0.26.3
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    libgcc: '>=14'
+    s2n: '>=1.7.2,<1.7.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-io-0.26.3-h73478e9_1.conda
+  hash:
+    md5: e9d3a9ab4391f0cbf46b7fe59319358a
+    sha256: af1fd1e0286d59115aa76b87f770e7c8a9c20f5fcec3c7a5ae56bb1dd041229d
+  category: container
+  optional: true
+- name: aws-c-io
+  version: 0.26.3
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    libgcc: '>=14'
+    s2n: '>=1.7.2,<1.7.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-io-0.26.3-h73478e9_1.conda
+  hash:
+    md5: e9d3a9ab4391f0cbf46b7fe59319358a
+    sha256: af1fd1e0286d59115aa76b87f770e7c8a9c20f5fcec3c7a5ae56bb1dd041229d
+  category: notebooks
+  optional: true
+- name: aws-c-io
+  version: 0.26.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.26.3-hc95b61d_2.conda
+  hash:
+    md5: 6056103306b72ddc7f85fe8579764c07
+    sha256: e3b6b0b68b1f8708ebbc1c4b8486939cdc26cbd1d8e9af51a719e41b9860f1bb
+  category: container
+  optional: true
+- name: aws-c-io
+  version: 0.26.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.26.3-hc95b61d_2.conda
+  hash:
+    md5: 6056103306b72ddc7f85fe8579764c07
+    sha256: e3b6b0b68b1f8708ebbc1c4b8486939cdc26cbd1d8e9af51a719e41b9860f1bb
+  category: notebooks
+  optional: true
+- name: aws-c-io
+  version: 0.26.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.26.3-h4137820_2.conda
+  hash:
+    md5: e18c6ab3c89c04be91b14f02386bc916
+    sha256: 953207d6854b41cb12c4ecfa49f15f5c21086df47c0535de8a5f3cc4eb3e70de
+  category: container
+  optional: true
+- name: aws-c-io
+  version: 0.26.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.26.3-h4137820_2.conda
+  hash:
+    md5: e18c6ab3c89c04be91b14f02386bc916
+    sha256: 953207d6854b41cb12c4ecfa49f15f5c21086df47c0535de8a5f3cc4eb3e70de
+  category: notebooks
+  optional: true
+- name: aws-c-mqtt
+  version: 0.15.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.15.2-hc1936db_2.conda
+  hash:
+    md5: 9120bc47b6f837f3cea90928c3e9a8fa
+    sha256: 236ab4138ff4600f95903d2da94125df78577055f6687afa8806db0f6ed2e1a8
+  category: container
+  optional: true
+- name: aws-c-mqtt
+  version: 0.15.2
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-mqtt-0.15.2-he7b6e36_2.conda
+  hash:
+    md5: 5c39ae8f97a3f4832ce7b6e26fd4029f
+    sha256: 080a50514497c7f9e0e1095298bd162e25702f9911e9b30bd7552a8e965c62b2
+  category: container
+  optional: true
+- name: aws-c-mqtt
+  version: 0.15.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.15.2-h377fd20_2.conda
+  hash:
+    md5: 636c0b11b63f8ee234388624caa971fb
+    sha256: 7f13b421167b55d296a92cf95f7c0793ec54a7da34da4749ea3eee9cb9e44306
+  category: container
+  optional: true
+- name: aws-c-mqtt
+  version: 0.15.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.15.2-h8860bc9_2.conda
+  hash:
+    md5: 826c667323e95b2af0223641c69f327c
+    sha256: 19a97f5d06ef994d7f48e77de3f998cc0a72d750d9363f2ba3894234c7bc799e
+  category: container
+  optional: true
+- name: aws-c-s3
+  version: 0.12.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-auth: '>=0.10.1,<0.10.2.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+    aws-checksums: '>=0.2.10,<0.2.11.0a0'
     libgcc: '>=14'
     openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.14-h78948cc_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.2-he6ee468_1.conda
   hash:
-    md5: fe81235aae00f32df8584267b4f2daf8
-    sha256: 06a0e2af439b21c94adff8fac5dd66dbda5f182fc80ac635c4903959ea306cbb
+    md5: 50ae8372984b8b98e056ac8f6b70ab29
+    sha256: 4cecb4d595b7cf558087c37b8131cae5204b2c64d75f6b951dc3731d3f872bb8
   category: container
   optional: true
-- name: aws-c-cal
-  version: 0.9.14
+- name: aws-c-s3
+  version: 0.12.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
+    aws-c-auth: '>=0.10.1,<0.10.2.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+    aws-checksums: '>=0.2.10,<0.2.11.0a0'
     libgcc: '>=14'
     openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.14-h78948cc_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.2-he6ee468_1.conda
   hash:
-    md5: fe81235aae00f32df8584267b4f2daf8
-    sha256: 06a0e2af439b21c94adff8fac5dd66dbda5f182fc80ac635c4903959ea306cbb
+    md5: 50ae8372984b8b98e056ac8f6b70ab29
+    sha256: 4cecb4d595b7cf558087c37b8131cae5204b2c64d75f6b951dc3731d3f872bb8
   category: notebooks
   optional: true
-- name: aws-c-cal
-  version: 0.9.14
+- name: aws-c-s3
+  version: 0.12.2
   manager: conda
   platform: linux-aarch64
   dependencies:
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
+    aws-c-auth: '>=0.10.1,<0.10.2.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+    aws-checksums: '>=0.2.10,<0.2.11.0a0'
     libgcc: '>=14'
     openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-cal-0.9.14-h343fa25_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-s3-0.12.2-h464689b_1.conda
   hash:
-    md5: 74b8d65bdec1ef7da95acde54a1d649b
-    sha256: 8e034414d5805fdb6ff7c6a2d44446792b8e4e32c20b53ce4f86999da64c590a
+    md5: bfbf8edf1f3de4c2420228c84de2b6a3
+    sha256: bd6e78fff624a5ae8c3772dc3eee9a836ed1015419658cf674908ff4c254f28c
   category: container
   optional: true
-- name: aws-c-cal
-  version: 0.9.14
+- name: aws-c-s3
+  version: 0.12.2
   manager: conda
   platform: linux-aarch64
   dependencies:
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
+    aws-c-auth: '>=0.10.1,<0.10.2.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+    aws-checksums: '>=0.2.10,<0.2.11.0a0'
     libgcc: '>=14'
     openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-cal-0.9.14-h343fa25_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-s3-0.12.2-h464689b_1.conda
   hash:
-    md5: 74b8d65bdec1ef7da95acde54a1d649b
-    sha256: 8e034414d5805fdb6ff7c6a2d44446792b8e4e32c20b53ce4f86999da64c590a
-  category: notebooks
-  optional: true
-- name: aws-c-cal
-  version: 0.9.14
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.9.14-hcb77be1_2.conda
-  hash:
-    md5: 18708874716ed71706c80769e8ba5409
-    sha256: d36ca9a9d031d381f2270480d834833e0fdb71d4793307b0a11b0ed7e45b63a0
-  category: container
-  optional: true
-- name: aws-c-cal
-  version: 0.9.14
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.9.14-hcb77be1_2.conda
-  hash:
-    md5: 18708874716ed71706c80769e8ba5409
-    sha256: d36ca9a9d031d381f2270480d834833e0fdb71d4793307b0a11b0ed7e45b63a0
-  category: notebooks
-  optional: true
-- name: aws-c-cal
-  version: 0.9.14
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.9.14-h81c6212_2.conda
-  hash:
-    md5: dcac0aa854a1f7f58a59226f5309a44e
-    sha256: 557bc47cbfd01dc569b930c102cd56ca5ba67750bd51a4fcee445246e7e536cd
-  category: container
-  optional: true
-- name: aws-c-cal
-  version: 0.9.14
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.9.14-h81c6212_2.conda
-  hash:
-    md5: dcac0aa854a1f7f58a59226f5309a44e
-    sha256: 557bc47cbfd01dc569b930c102cd56ca5ba67750bd51a4fcee445246e7e536cd
-  category: notebooks
-  optional: true
-- name: aws-c-common
-  version: 0.14.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.14.0-hb03c661_0.conda
-  hash:
-    md5: f1c005b2e3b618706112ddd7f3af4521
-    sha256: 6d2b33965bf6daeffd3ad336f41410053ff06ed6f2b2ce62c1ec27c0a39b4e7e
-  category: container
-  optional: true
-- name: aws-c-common
-  version: 0.14.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.14.0-hb03c661_0.conda
-  hash:
-    md5: f1c005b2e3b618706112ddd7f3af4521
-    sha256: 6d2b33965bf6daeffd3ad336f41410053ff06ed6f2b2ce62c1ec27c0a39b4e7e
-  category: notebooks
-  optional: true
-- name: aws-c-common
-  version: 0.14.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-common-0.14.0-he30d5cf_0.conda
-  hash:
-    md5: 18a6c06d8874981e1bf97b11bde95d4b
-    sha256: 2151746543fe6f53fea754a2eafaee5c1aae3ab5653cfb7d4e684adc0b44034b
-  category: container
-  optional: true
-- name: aws-c-common
-  version: 0.14.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-common-0.14.0-he30d5cf_0.conda
-  hash:
-    md5: 18a6c06d8874981e1bf97b11bde95d4b
-    sha256: 2151746543fe6f53fea754a2eafaee5c1aae3ab5653cfb7d4e684adc0b44034b
-  category: notebooks
-  optional: true
-- name: aws-c-common
-  version: 0.14.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.14.0-ha1e9b39_0.conda
-  hash:
-    md5: 983f44cf7123c92ddbb19e9398f577ea
-    sha256: c07dca511740b30b3bb26d9d5d14ce2577e65c422bc0afb875581792242a4514
-  category: container
-  optional: true
-- name: aws-c-common
-  version: 0.14.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.14.0-ha1e9b39_0.conda
-  hash:
-    md5: 983f44cf7123c92ddbb19e9398f577ea
-    sha256: c07dca511740b30b3bb26d9d5d14ce2577e65c422bc0afb875581792242a4514
-  category: notebooks
-  optional: true
-- name: aws-c-common
-  version: 0.14.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.14.0-h84a0fba_0.conda
-  hash:
-    md5: 3a49923f2b3987a833a264caca603f84
-    sha256: 223f67551038366555e6934802d8b375547b142157aad3fc3654c720ac1525c0
-  category: container
-  optional: true
-- name: aws-c-common
-  version: 0.14.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.14.0-h84a0fba_0.conda
-  hash:
-    md5: 3a49923f2b3987a833a264caca603f84
-    sha256: 223f67551038366555e6934802d8b375547b142157aad3fc3654c720ac1525c0
-  category: notebooks
-  optional: true
-- name: aws-c-compression
-  version: 0.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.2-haa0cbde_2.conda
-  hash:
-    md5: 595911421e25551e36fde7027bf33f38
-    sha256: 0e4952f9be8de7f281ca7d734a3a8f05ad0db856c6ef1e0897798c4afbcd9a54
-  category: container
-  optional: true
-- name: aws-c-compression
-  version: 0.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.2-haa0cbde_2.conda
-  hash:
-    md5: 595911421e25551e36fde7027bf33f38
-    sha256: 0e4952f9be8de7f281ca7d734a3a8f05ad0db856c6ef1e0897798c4afbcd9a54
-  category: notebooks
-  optional: true
-- name: aws-c-compression
-  version: 0.3.2
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h5b0efec_2.conda
-  hash:
-    md5: 4cdf3f4e3f148e7b8c75685d19c373ea
-    sha256: ecb5986725571eab54e8a20e5b0a189171b51c494bbdfb019c34bb33218d608a
-  category: container
-  optional: true
-- name: aws-c-compression
-  version: 0.3.2
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h5b0efec_2.conda
-  hash:
-    md5: 4cdf3f4e3f148e7b8c75685d19c373ea
-    sha256: ecb5986725571eab54e8a20e5b0a189171b51c494bbdfb019c34bb33218d608a
-  category: notebooks
-  optional: true
-- name: aws-c-compression
-  version: 0.3.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.2-ha04291d_2.conda
-  hash:
-    md5: a7163d39a3e639901fc1ce4865e11b47
-    sha256: 7e3de1e42fb88192f1e39bb3d9024d3b228ad06b94508056d0d2175448387706
-  category: container
-  optional: true
-- name: aws-c-compression
-  version: 0.3.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.2-ha04291d_2.conda
-  hash:
-    md5: a7163d39a3e639901fc1ce4865e11b47
-    sha256: 7e3de1e42fb88192f1e39bb3d9024d3b228ad06b94508056d0d2175448387706
-  category: notebooks
-  optional: true
-- name: aws-c-compression
-  version: 0.3.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.2-h61d3404_2.conda
-  hash:
-    md5: 497edff11fcb32865d8c5d6ab3aef6e0
-    sha256: 4289ff476103d109623bd413b12d61307d6267e87fc6a8c29b0aec71dfa8fd84
-  category: container
-  optional: true
-- name: aws-c-compression
-  version: 0.3.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.2-h61d3404_2.conda
-  hash:
-    md5: 497edff11fcb32865d8c5d6ab3aef6e0
-    sha256: 4289ff476103d109623bd413b12d61307d6267e87fc6a8c29b0aec71dfa8fd84
-  category: notebooks
-  optional: true
-- name: aws-c-event-stream
-  version: 0.7.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-checksums: '>=0.2.10,<0.2.11.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.7.1-h9cf6be0_2.conda
-  hash:
-    md5: 2c304605f9074f072c92c0d8de175a1a
-    sha256: 6b893ba3173206e17fef1b9c8b683c6f6ecbca7127770c8d0f3ba13d123f8d4c
-  category: container
-  optional: true
-- name: aws-c-event-stream
-  version: 0.7.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-checksums: '>=0.2.10,<0.2.11.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.7.1-h9cf6be0_2.conda
-  hash:
-    md5: 2c304605f9074f072c92c0d8de175a1a
-    sha256: 6b893ba3173206e17fef1b9c8b683c6f6ecbca7127770c8d0f3ba13d123f8d4c
-  category: notebooks
-  optional: true
-- name: aws-c-event-stream
-  version: 0.7.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-checksums: '>=0.2.10,<0.2.11.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-event-stream-0.7.1-h70cbb06_2.conda
-  hash:
-    md5: 469ff7442d34751631a5f5bfddd2ef8a
-    sha256: 657e93b584856b4f253447d3ced5538a51dce4cfad6b264ef56d40a85126ed57
-  category: container
-  optional: true
-- name: aws-c-event-stream
-  version: 0.7.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-checksums: '>=0.2.10,<0.2.11.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-event-stream-0.7.1-h70cbb06_2.conda
-  hash:
-    md5: 469ff7442d34751631a5f5bfddd2ef8a
-    sha256: 657e93b584856b4f253447d3ced5538a51dce4cfad6b264ef56d40a85126ed57
-  category: notebooks
-  optional: true
-- name: aws-c-event-stream
-  version: 0.7.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-checksums: '>=0.2.10,<0.2.11.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.7.1-hf02f33c_2.conda
-  hash:
-    md5: ea1fd47007bf4362c1d17e388af42479
-    sha256: 52166148575189fb6fcbe272900ab3e1066cbf2af6e2d81d4408fe366211dc54
-  category: container
-  optional: true
-- name: aws-c-event-stream
-  version: 0.7.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-checksums: '>=0.2.10,<0.2.11.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.7.1-hf02f33c_2.conda
-  hash:
-    md5: ea1fd47007bf4362c1d17e388af42479
-    sha256: 52166148575189fb6fcbe272900ab3e1066cbf2af6e2d81d4408fe366211dc54
-  category: notebooks
-  optional: true
-- name: aws-c-event-stream
-  version: 0.7.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-checksums: '>=0.2.10,<0.2.11.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.7.1-h7e6a3cf_2.conda
-  hash:
-    md5: 608685880a69722c685d1729c57409f6
-    sha256: 5e0c69837e21fc17cc26ad6c252e842a96bb16f5be2c6f06f48a13b8a56fc56f
-  category: container
-  optional: true
-- name: aws-c-event-stream
-  version: 0.7.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-checksums: '>=0.2.10,<0.2.11.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.7.1-h7e6a3cf_2.conda
-  hash:
-    md5: 608685880a69722c685d1729c57409f6
-    sha256: 5e0c69837e21fc17cc26ad6c252e842a96bb16f5be2c6f06f48a13b8a56fc56f
-  category: notebooks
-  optional: true
-- name: aws-c-http
-  version: 0.11.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-compression: '>=0.3.2,<0.3.3.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.11.0-h6488f85_2.conda
-  hash:
-    md5: da0be1e8cb4a43c876f26d9d812dea06
-    sha256: d2b844db1a4dfbc20b5129b7df4a656c1459c5fb16745101bbd802813ba8d411
-  category: container
-  optional: true
-- name: aws-c-http
-  version: 0.11.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-compression: '>=0.3.2,<0.3.3.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.11.0-h6488f85_2.conda
-  hash:
-    md5: da0be1e8cb4a43c876f26d9d812dea06
-    sha256: d2b844db1a4dfbc20b5129b7df4a656c1459c5fb16745101bbd802813ba8d411
-  category: notebooks
-  optional: true
-- name: aws-c-http
-  version: 0.11.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-compression: '>=0.3.2,<0.3.3.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-http-0.11.0-h9bcd1b7_2.conda
-  hash:
-    md5: 7a2cfa541ed40c59f221e03b2e63d7e2
-    sha256: 2261f841fae2fe87ed5dd61897eeeb3aa72a946ff3cf7d9474289820fd6914e5
-  category: container
-  optional: true
-- name: aws-c-http
-  version: 0.11.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-compression: '>=0.3.2,<0.3.3.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-http-0.11.0-h9bcd1b7_2.conda
-  hash:
-    md5: 7a2cfa541ed40c59f221e03b2e63d7e2
-    sha256: 2261f841fae2fe87ed5dd61897eeeb3aa72a946ff3cf7d9474289820fd6914e5
-  category: notebooks
-  optional: true
-- name: aws-c-http
-  version: 0.11.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-compression: '>=0.3.2,<0.3.3.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.11.0-he315c99_2.conda
-  hash:
-    md5: aa2b61bf50c3c666683488fef3187436
-    sha256: 181d69666b6d7dab3669c2bf964971495c0b1dfa6a5823bf0626d8f53e1f56fb
-  category: container
-  optional: true
-- name: aws-c-http
-  version: 0.11.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-compression: '>=0.3.2,<0.3.3.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.11.0-he315c99_2.conda
-  hash:
-    md5: aa2b61bf50c3c666683488fef3187436
-    sha256: 181d69666b6d7dab3669c2bf964971495c0b1dfa6a5823bf0626d8f53e1f56fb
-  category: notebooks
-  optional: true
-- name: aws-c-http
-  version: 0.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-compression: '>=0.3.2,<0.3.3.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.11.0-h0a63974_2.conda
-  hash:
-    md5: f0fc8139091eb8245209bb9ee8911a82
-    sha256: 06d3b08ed19cd63fd75750e325f19ebf7183b22ee27cbe2ca7b7dd6725d34885
-  category: container
-  optional: true
-- name: aws-c-http
-  version: 0.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-compression: '>=0.3.2,<0.3.3.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.11.0-h0a63974_2.conda
-  hash:
-    md5: f0fc8139091eb8245209bb9ee8911a82
-    sha256: 06d3b08ed19cd63fd75750e325f19ebf7183b22ee27cbe2ca7b7dd6725d34885
-  category: notebooks
-  optional: true
-- name: aws-c-io
-  version: 0.26.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    libgcc: '>=14'
-    s2n: '>=1.7.4,<1.7.5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h3bf836e_5.conda
-  hash:
-    md5: 12697e83c2a0e5b93fd03855a70eb360
-    sha256: c798005b65bc74d02aba1db01d4d344c4e72662f0beef35fbdd35b4695c197de
-  category: container
-  optional: true
-- name: aws-c-io
-  version: 0.26.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    libgcc: '>=14'
-    s2n: '>=1.7.4,<1.7.5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.26.3-h3bf836e_5.conda
-  hash:
-    md5: 12697e83c2a0e5b93fd03855a70eb360
-    sha256: c798005b65bc74d02aba1db01d4d344c4e72662f0beef35fbdd35b4695c197de
-  category: notebooks
-  optional: true
-- name: aws-c-io
-  version: 0.26.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    libgcc: '>=14'
-    s2n: '>=1.7.4,<1.7.5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-io-0.26.3-hacd6ab7_5.conda
-  hash:
-    md5: 6a4abaf2e970323cc7056f4a2f639ca6
-    sha256: 2cb4a129d119356f0e7f02d36ff0625b856ec94db49018d0ef9ff5f7e61681a3
-  category: container
-  optional: true
-- name: aws-c-io
-  version: 0.26.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    libgcc: '>=14'
-    s2n: '>=1.7.4,<1.7.5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-io-0.26.3-hacd6ab7_5.conda
-  hash:
-    md5: 6a4abaf2e970323cc7056f4a2f639ca6
-    sha256: 2cb4a129d119356f0e7f02d36ff0625b856ec94db49018d0ef9ff5f7e61681a3
-  category: notebooks
-  optional: true
-- name: aws-c-io
-  version: 0.26.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.26.3-hd35ae92_5.conda
-  hash:
-    md5: fb95a47b03779f66e588fc52f1c117d9
-    sha256: 8ec4264e9bf8f1e59d22c05e3df7383f118080b4123eeb6fd265ffcad08c444c
-  category: container
-  optional: true
-- name: aws-c-io
-  version: 0.26.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.26.3-hd35ae92_5.conda
-  hash:
-    md5: fb95a47b03779f66e588fc52f1c117d9
-    sha256: 8ec4264e9bf8f1e59d22c05e3df7383f118080b4123eeb6fd265ffcad08c444c
-  category: notebooks
-  optional: true
-- name: aws-c-io
-  version: 0.26.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_5.conda
-  hash:
-    md5: 3f3d6b053bc85cf224ac53ee8a32fcf0
-    sha256: 82b51f24e391dcf4750a238ed84368e09bf00c8295d0206e92e85cc78ef3a3b9
-  category: container
-  optional: true
-- name: aws-c-io
-  version: 0.26.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_5.conda
-  hash:
-    md5: 3f3d6b053bc85cf224ac53ee8a32fcf0
-    sha256: 82b51f24e391dcf4750a238ed84368e09bf00c8295d0206e92e85cc78ef3a3b9
-  category: notebooks
-  optional: true
-- name: aws-c-mqtt
-  version: 0.16.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.16.0-h0d2f46f_0.conda
-  hash:
-    md5: 94454ba09f610904865601eae5530600
-    sha256: 2a9ae1da09ae77d0d513ebaaa0e3810f33e4e09b564494c62d50d7d9f217334e
-  category: container
-  optional: true
-- name: aws-c-mqtt
-  version: 0.16.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.16.0-h0d2f46f_0.conda
-  hash:
-    md5: 94454ba09f610904865601eae5530600
-    sha256: 2a9ae1da09ae77d0d513ebaaa0e3810f33e4e09b564494c62d50d7d9f217334e
-  category: notebooks
-  optional: true
-- name: aws-c-mqtt
-  version: 0.16.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-mqtt-0.16.0-h3479d1b_0.conda
-  hash:
-    md5: 5d6c352a3ddf21cb58e2afbecd0dfdfc
-    sha256: 5dfb678f299f258dd54ba39bbb0b43b31f7393c999a386a328edf794e652a1ed
-  category: container
-  optional: true
-- name: aws-c-mqtt
-  version: 0.16.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-mqtt-0.16.0-h3479d1b_0.conda
-  hash:
-    md5: 5d6c352a3ddf21cb58e2afbecd0dfdfc
-    sha256: 5dfb678f299f258dd54ba39bbb0b43b31f7393c999a386a328edf794e652a1ed
-  category: notebooks
-  optional: true
-- name: aws-c-mqtt
-  version: 0.16.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.16.0-h60a7cf6_0.conda
-  hash:
-    md5: 77e280c0efc9dcc063e2979e8c2a7371
-    sha256: c4b02491a15e7ca6e92856c2f3712f6726bf412e11938228c8c375b272129730
-  category: container
-  optional: true
-- name: aws-c-mqtt
-  version: 0.16.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.16.0-h60a7cf6_0.conda
-  hash:
-    md5: 77e280c0efc9dcc063e2979e8c2a7371
-    sha256: c4b02491a15e7ca6e92856c2f3712f6726bf412e11938228c8c375b272129730
-  category: notebooks
-  optional: true
-- name: aws-c-mqtt
-  version: 0.16.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.16.0-ha70999f_0.conda
-  hash:
-    md5: 23ef6506ce17c3ed79db869898f99598
-    sha256: 311a2051eb2e48664229a9b10886013c4c059aef602b70909ac1bc8d2000fc6d
-  category: container
-  optional: true
-- name: aws-c-mqtt
-  version: 0.16.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.16.0-ha70999f_0.conda
-  hash:
-    md5: 23ef6506ce17c3ed79db869898f99598
-    sha256: 311a2051eb2e48664229a9b10886013c4c059aef602b70909ac1bc8d2000fc6d
+    md5: bfbf8edf1f3de4c2420228c84de2b6a3
+    sha256: bd6e78fff624a5ae8c3772dc3eee9a836ed1015419658cf674908ff4c254f28c
   category: notebooks
   optional: true
 - name: aws-c-s3
-  version: 0.12.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-checksums: '>=0.2.10,<0.2.11.0a0'
-    libgcc: '>=14'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.6-hb916526_0.conda
-  hash:
-    md5: f2b6275244daa12109bcd0a126f1fb85
-    sha256: bda2c735382e2232997fb34c5d71d476ab2f4e5ba5bc9e059106f280f2334a88
-  category: container
-  optional: true
-- name: aws-c-s3
-  version: 0.12.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-checksums: '>=0.2.10,<0.2.11.0a0'
-    libgcc: '>=14'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.6-hb916526_0.conda
-  hash:
-    md5: f2b6275244daa12109bcd0a126f1fb85
-    sha256: bda2c735382e2232997fb34c5d71d476ab2f4e5ba5bc9e059106f280f2334a88
-  category: notebooks
-  optional: true
-- name: aws-c-s3
-  version: 0.12.6
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-checksums: '>=0.2.10,<0.2.11.0a0'
-    libgcc: '>=14'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-s3-0.12.6-hdd40dfe_0.conda
-  hash:
-    md5: 88df147dd58567e2a18eabd84d37f79f
-    sha256: 9a62d67348d140c5b626f72f1d5f5192e6ea0cbdf047e7ebd9f46f33f63e268a
-  category: container
-  optional: true
-- name: aws-c-s3
-  version: 0.12.6
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-checksums: '>=0.2.10,<0.2.11.0a0'
-    libgcc: '>=14'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-s3-0.12.6-hdd40dfe_0.conda
-  hash:
-    md5: 88df147dd58567e2a18eabd84d37f79f
-    sha256: 9a62d67348d140c5b626f72f1d5f5192e6ea0cbdf047e7ebd9f46f33f63e268a
-  category: notebooks
-  optional: true
-- name: aws-c-s3
-  version: 0.12.6
+  version: 0.12.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    aws-c-auth: '>=0.10.1,<0.10.2.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.12.6-h8cc6e82_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.12.2-hfe16a33_1.conda
   hash:
-    md5: 9cdf6d338f7553cd715b2569b8d34ce6
-    sha256: d692471963cebb98a895bda88934c8b629b3c9eb2a39290a74ffbf5769a15f7c
+    md5: 84be59d0b0107cc0ba06983a2a05070d
+    sha256: df4040780a6331295563fa9e251266d150920bcf5359dd6d6960f07403480b31
   category: container
   optional: true
 - name: aws-c-s3
-  version: 0.12.6
+  version: 0.12.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    aws-c-auth: '>=0.10.1,<0.10.2.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.12.6-h8cc6e82_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.12.2-hfe16a33_1.conda
   hash:
-    md5: 9cdf6d338f7553cd715b2569b8d34ce6
-    sha256: d692471963cebb98a895bda88934c8b629b3c9eb2a39290a74ffbf5769a15f7c
+    md5: 84be59d0b0107cc0ba06983a2a05070d
+    sha256: df4040780a6331295563fa9e251266d150920bcf5359dd6d6960f07403480b31
   category: notebooks
   optional: true
 - name: aws-c-s3
-  version: 0.12.6
+  version: 0.12.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    aws-c-auth: '>=0.10.1,<0.10.2.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.2-h07b101a_1.conda
   hash:
-    md5: 912c61c44a2782693d63af2272551455
-    sha256: 258678f29912d503e4301814f411b29bb2324f6a0131a06a385f2280b4916eeb
+    md5: 7a520ebd6ae9efe641cb207b650d004c
+    sha256: 236b4acfc8b0757e427087b53ebaf090190d106a7e73b6b1e8f80388988e89ac
   category: container
   optional: true
 - name: aws-c-s3
-  version: 0.12.6
+  version: 0.12.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    aws-c-auth: '>=0.10.1,<0.10.2.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.2-h07b101a_1.conda
   hash:
-    md5: 912c61c44a2782693d63af2272551455
-    sha256: 258678f29912d503e4301814f411b29bb2324f6a0131a06a385f2280b4916eeb
+    md5: 7a520ebd6ae9efe641cb207b650d004c
+    sha256: 236b4acfc8b0757e427087b53ebaf090190d106a7e73b6b1e8f80388988e89ac
   category: notebooks
   optional: true
 - name: aws-c-sdkutils
-  version: 0.2.5
+  version: 0.2.4
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.5-haa0cbde_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
   hash:
-    md5: 5088795f3dfcf00a26f03c2a17ae8429
-    sha256: c351a2bb8734accc6a047b55be15a8ce205725aeeedd2576c320841c3c383731
+    md5: c7e3e08b7b1b285524ab9d74162ce40b
+    sha256: 9d62c5029f6f8219368a8665f0a549da572dc777f52413b7d75609cacdbc02cc
   category: container
   optional: true
 - name: aws-c-sdkutils
-  version: 0.2.5
+  version: 0.2.4
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.5-haa0cbde_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
   hash:
-    md5: 5088795f3dfcf00a26f03c2a17ae8429
-    sha256: c351a2bb8734accc6a047b55be15a8ce205725aeeedd2576c320841c3c383731
+    md5: c7e3e08b7b1b285524ab9d74162ce40b
+    sha256: 9d62c5029f6f8219368a8665f0a549da572dc777f52413b7d75609cacdbc02cc
   category: notebooks
   optional: true
 - name: aws-c-sdkutils
-  version: 0.2.5
+  version: 0.2.4
   manager: conda
   platform: linux-aarch64
   dependencies:
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.5-h5b0efec_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h6f28e42_4.conda
   hash:
-    md5: 63d2469f561dbd794d4e73de32f16fb5
-    sha256: 2cdcddc176ad9a255e4f38c20eb72ee45bad879ac43f080c1ccb2f6ff06fd950
+    md5: 92b452c0a36ed41ae93db16662f7ee8b
+    sha256: 33c5279607c4b47cdd6e7217d70410ced7b67aa430aa98f77a55c068600dff09
   category: container
   optional: true
 - name: aws-c-sdkutils
-  version: 0.2.5
+  version: 0.2.4
   manager: conda
   platform: linux-aarch64
   dependencies:
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.5-h5b0efec_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h6f28e42_4.conda
   hash:
-    md5: 63d2469f561dbd794d4e73de32f16fb5
-    sha256: 2cdcddc176ad9a255e4f38c20eb72ee45bad879ac43f080c1ccb2f6ff06fd950
+    md5: 92b452c0a36ed41ae93db16662f7ee8b
+    sha256: 33c5279607c4b47cdd6e7217d70410ced7b67aa430aa98f77a55c068600dff09
   category: notebooks
   optional: true
 - name: aws-c-sdkutils
-  version: 0.2.5
+  version: 0.2.4
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.5-ha04291d_0.conda
+    __osx: '>=10.13'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.4-h901532c_4.conda
   hash:
-    md5: a419d964954a7885cd5c10bc79d5ccf5
-    sha256: bfa4583104c63c3a0ffb5b68bc78aff0f75089bce2e5f68933599de4be543e61
+    md5: b384fb05730f549a55cdb13c484861eb
+    sha256: 468629dbf52fee6dcabda1fcb0c0f2f29941b9001dcc75a57ebfbe38d0bde713
   category: container
   optional: true
 - name: aws-c-sdkutils
-  version: 0.2.5
+  version: 0.2.4
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.5-ha04291d_0.conda
+    __osx: '>=10.13'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.4-h901532c_4.conda
   hash:
-    md5: a419d964954a7885cd5c10bc79d5ccf5
-    sha256: bfa4583104c63c3a0ffb5b68bc78aff0f75089bce2e5f68933599de4be543e61
+    md5: b384fb05730f549a55cdb13c484861eb
+    sha256: 468629dbf52fee6dcabda1fcb0c0f2f29941b9001dcc75a57ebfbe38d0bde713
   category: notebooks
   optional: true
 - name: aws-c-sdkutils
-  version: 0.2.5
+  version: 0.2.4
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h16f91aa_4.conda
   hash:
-    md5: 4a91f77674daaa9e0a6bbcf9a45d23fd
-    sha256: f47cd32244c77d12bfbf9ae1eecf6672d776f9df8f5357c365fd8254e3d2acb9
+    md5: 658a8236f3f1ebecaaa937b5ccd5d730
+    sha256: 8a4ee03ea6e14d5a498657e5fe96875a133b4263b910c5b60176db1a1a0aaa27
   category: container
   optional: true
 - name: aws-c-sdkutils
-  version: 0.2.5
+  version: 0.2.4
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h16f91aa_4.conda
   hash:
-    md5: 4a91f77674daaa9e0a6bbcf9a45d23fd
-    sha256: f47cd32244c77d12bfbf9ae1eecf6672d776f9df8f5357c365fd8254e3d2acb9
+    md5: 658a8236f3f1ebecaaa937b5ccd5d730
+    sha256: 8a4ee03ea6e14d5a498657e5fe96875a133b4263b910c5b60176db1a1a0aaa27
   category: notebooks
   optional: true
 - name: aws-checksums
@@ -2771,12 +2645,12 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-haa0cbde_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
   hash:
-    md5: 5c05a63452bf73c50aa272a6f961c4fc
-    sha256: ad49333d96a5f9bcce02752a6515cbb077d7513e358a8fb1a832f4e772d54bac
+    md5: f8e1bcc5c7d839c5882e94498791be08
+    sha256: 09472dd5fa4473cffd44741ee4c1112f2c76d7168d1343de53c2ad283dc1efa6
   category: container
   optional: true
 - name: aws-checksums
@@ -2785,12 +2659,12 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-haa0cbde_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
   hash:
-    md5: 5c05a63452bf73c50aa272a6f961c4fc
-    sha256: ad49333d96a5f9bcce02752a6515cbb077d7513e358a8fb1a832f4e772d54bac
+    md5: f8e1bcc5c7d839c5882e94498791be08
+    sha256: 09472dd5fa4473cffd44741ee4c1112f2c76d7168d1343de53c2ad283dc1efa6
   category: notebooks
   optional: true
 - name: aws-checksums
@@ -2798,12 +2672,12 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-checksums-0.2.10-h5b0efec_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-checksums-0.2.10-h6f28e42_0.conda
   hash:
-    md5: 1f8e43bb5e4f27d3b1f502b6f928ccdf
-    sha256: 5caf0bc9b514034718857342b1c6823a270f3cc8ad8045baeea44f80e4a9067d
+    md5: 17dbd98b7b170b74b8434428c3a442bc
+    sha256: c8c7743eb555f9cfc541aa7ebfa23992e74cac0b6f4bac13a4a62851016e6f16
   category: container
   optional: true
 - name: aws-checksums
@@ -2811,12 +2685,12 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-checksums-0.2.10-h5b0efec_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-checksums-0.2.10-h6f28e42_0.conda
   hash:
-    md5: 1f8e43bb5e4f27d3b1f502b6f928ccdf
-    sha256: 5caf0bc9b514034718857342b1c6823a270f3cc8ad8045baeea44f80e4a9067d
+    md5: 17dbd98b7b170b74b8434428c3a442bc
+    sha256: c8c7743eb555f9cfc541aa7ebfa23992e74cac0b6f4bac13a4a62851016e6f16
   category: notebooks
   optional: true
 - name: aws-checksums
@@ -2825,11 +2699,11 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.10-ha04291d_2.conda
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.10-h31279ed_0.conda
   hash:
-    md5: 81edba692bcff370dbf8e64660097c8d
-    sha256: 5ba7da95d95800d1fcd21397a7ddcea505faee420b2efb21b35cd12a50ad7154
+    md5: 28a458ade86d135a90951d816760cc5c
+    sha256: 8776d3d51e03ba373a13e4cd4adaf70fd15323c50f1dde85669dc4e379c10dbd
   category: container
   optional: true
 - name: aws-checksums
@@ -2838,11 +2712,11 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.10-ha04291d_2.conda
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.10-h31279ed_0.conda
   hash:
-    md5: 81edba692bcff370dbf8e64660097c8d
-    sha256: 5ba7da95d95800d1fcd21397a7ddcea505faee420b2efb21b35cd12a50ad7154
+    md5: 28a458ade86d135a90951d816760cc5c
+    sha256: 8776d3d51e03ba373a13e4cd4adaf70fd15323c50f1dde85669dc4e379c10dbd
   category: notebooks
   optional: true
 - name: aws-checksums
@@ -2851,11 +2725,11 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.10-h61d3404_2.conda
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.10-h3e7f9b5_0.conda
   hash:
-    md5: 7c5f6a6efce80e728c1f743e064ab657
-    sha256: 9af1483700bb29870297e2390838d3c31293e8cf80fd8a8a9bd9a1446020a8d8
+    md5: 07f6c5a5238f5deeed6e985826b30de8
+    sha256: 06661bc848b27aa38a85d8018ace8d4f4a3069e22fa0963e2431dc6c0dc30450
   category: container
   optional: true
 - name: aws-checksums
@@ -2864,970 +2738,203 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.10-h61d3404_2.conda
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.10-h3e7f9b5_0.conda
   hash:
-    md5: 7c5f6a6efce80e728c1f743e064ab657
-    sha256: 9af1483700bb29870297e2390838d3c31293e8cf80fd8a8a9bd9a1446020a8d8
+    md5: 07f6c5a5238f5deeed6e985826b30de8
+    sha256: 06661bc848b27aa38a85d8018ace8d4f4a3069e22fa0963e2431dc6c0dc30450
   category: notebooks
   optional: true
-- name: aws-crt-cpp
-  version: 0.40.1
+- name: awscli
+  version: 2.35.11
+  manager: conda
+  platform: linux-64
+  dependencies:
+    awscrt: 0.32.2
+    colorama: '>=0.2.5,<0.4.7'
+    distro: '>=1.5.0,<1.9.0'
+    docutils: '>=0.10,<0.20'
+    jmespath: '>=0.7.1,<1.1.0'
+    prompt-toolkit: '>=3.0.24,<3.0.52'
+    python: ''
+    python-dateutil: '>=2.1,<=2.9.0'
+    python_abi: 3.13.*
+    ruamel.yaml: '>=0.15.0,<=0.19.1'
+    ruamel.yaml.clib: '>=0.2.0,<=0.2.15'
+    urllib3: '>=1.25.4,<=2.6.3'
+    wcwidth: <0.3.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.35.11-py313hd5f5364_0.conda
+  hash:
+    md5: bff6b8c6fb04428a7adcadd19096a166
+    sha256: d2e06eac4eb3d4fe06b38a3ba5e1f111f32532b3ec9540d3c0771d62681038ed
+  category: container
+  optional: true
+- name: awscli
+  version: 2.35.11
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    awscrt: 0.32.2
+    colorama: '>=0.2.5,<0.4.7'
+    distro: '>=1.5.0,<1.9.0'
+    docutils: '>=0.10,<0.20'
+    jmespath: '>=0.7.1,<1.1.0'
+    prompt-toolkit: '>=3.0.24,<3.0.52'
+    python: 3.13.*
+    python-dateutil: '>=2.1,<=2.9.0'
+    python_abi: 3.13.*
+    ruamel.yaml: '>=0.15.0,<=0.19.1'
+    ruamel.yaml.clib: '>=0.2.0,<=0.2.15'
+    urllib3: '>=1.25.4,<=2.6.3'
+    wcwidth: <0.3.0
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/awscli-2.35.11-py313he159727_0.conda
+  hash:
+    md5: 29486a74b1f0fe7cb444e36a82b7de03
+    sha256: 506a3ffdfc00dedd59ad31c008105b5287b3c3b2b26a42e849b5db3b8dfeaebf
+  category: container
+  optional: true
+- name: awscli
+  version: 2.35.11
+  manager: conda
+  platform: osx-64
+  dependencies:
+    awscrt: 0.32.2
+    colorama: '>=0.2.5,<0.4.7'
+    distro: '>=1.5.0,<1.9.0'
+    docutils: '>=0.10,<0.20'
+    jmespath: '>=0.7.1,<1.1.0'
+    prompt-toolkit: '>=3.0.24,<3.0.52'
+    python: ''
+    python-dateutil: '>=2.1,<=2.9.0'
+    python_abi: 3.13.*
+    ruamel.yaml: '>=0.15.0,<=0.19.1'
+    ruamel.yaml.clib: '>=0.2.0,<=0.2.15'
+    urllib3: '>=1.25.4,<=2.6.3'
+    wcwidth: <0.3.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/awscli-2.35.11-py313h11baec3_0.conda
+  hash:
+    md5: 4e45de8e77e1372f34c0987477dc4dc1
+    sha256: 3d5746c224cb3750588da793b9c13312febe71f35d73c1fc088159eab4804ce8
+  category: container
+  optional: true
+- name: awscli
+  version: 2.35.11
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    awscrt: 0.32.2
+    colorama: '>=0.2.5,<0.4.7'
+    distro: '>=1.5.0,<1.9.0'
+    docutils: '>=0.10,<0.20'
+    jmespath: '>=0.7.1,<1.1.0'
+    prompt-toolkit: '>=3.0.24,<3.0.52'
+    python: 3.13.*
+    python-dateutil: '>=2.1,<=2.9.0'
+    python_abi: 3.13.*
+    ruamel.yaml: '>=0.15.0,<=0.19.1'
+    ruamel.yaml.clib: '>=0.2.0,<=0.2.15'
+    urllib3: '>=1.25.4,<=2.6.3'
+    wcwidth: <0.3.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/awscli-2.35.11-py313h6fa1262_0.conda
+  hash:
+    md5: 82dfe47dc4b69767af4a980acd6d312d
+    sha256: af2d989e343a2abee19b2882c504b7e35a181dd0c5cb925fe12cf0862815e1b5
+  category: container
+  optional: true
+- name: awscrt
+  version: 0.32.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    aws-c-auth: '>=0.10.1,<0.10.2.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-event-stream: '>=0.7.0,<0.7.1.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-mqtt: '>=0.16.0,<0.16.1.0a0'
-    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
+    aws-c-mqtt: '>=0.15.2,<0.15.3.0a0'
+    aws-c-s3: '>=0.12.2,<0.12.3.0a0'
+    aws-checksums: '>=0.2.10,<0.2.11.0a0'
     libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.40.1-h7a9a9d6_1.conda
+    python: ''
+    python_abi: 3.13.*
+    s2n: '>=1.7.2,<1.7.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.32.2-py313h15cf2f3_0.conda
   hash:
-    md5: 976bc22e043e8380f3dd54863b73ecef
-    sha256: 55d39d93aaa69ac47831db4c0661b8112e719d74950fecd4bcbf9181ea6f7d34
+    md5: 3cd9e9c79309e5dbef6c3ff093a4d66e
+    sha256: 27a052c103075742f40ebdb3d861e45eeb27544702354df0f7cd6a34d82b55a2
   category: container
   optional: true
-- name: aws-crt-cpp
-  version: 0.40.1
+- name: awscrt
+  version: 0.32.2
   manager: conda
-  platform: linux-64
+  platform: linux-aarch64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    aws-c-auth: '>=0.10.1,<0.10.2.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-event-stream: '>=0.7.0,<0.7.1.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-mqtt: '>=0.16.0,<0.16.1.0a0'
-    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
+    aws-c-mqtt: '>=0.15.2,<0.15.3.0a0'
+    aws-c-s3: '>=0.12.2,<0.12.3.0a0'
+    aws-checksums: '>=0.2.10,<0.2.11.0a0'
     libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.40.1-h7a9a9d6_1.conda
+    python: 3.13.*
+    python_abi: 3.13.*
+    s2n: '>=1.7.2,<1.7.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/awscrt-0.32.2-py313hd4e6407_0.conda
   hash:
-    md5: 976bc22e043e8380f3dd54863b73ecef
-    sha256: 55d39d93aaa69ac47831db4c0661b8112e719d74950fecd4bcbf9181ea6f7d34
-  category: notebooks
+    md5: 11ad3821672d39691ab40354f3b4b51a
+    sha256: ff1a5393b1007316195c48480ba5a27680c5ddc8a5deecdbe6142af715e3e386
+  category: container
   optional: true
-- name: aws-crt-cpp
-  version: 0.40.1
+- name: awscrt
+  version: 0.32.2
   manager: conda
-  platform: linux-aarch64
+  platform: osx-64
   dependencies:
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    __osx: '>=11.0'
+    aws-c-auth: '>=0.10.1,<0.10.2.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-event-stream: '>=0.7.0,<0.7.1.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-mqtt: '>=0.16.0,<0.16.1.0a0'
-    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-crt-cpp-0.40.1-h0495e26_1.conda
+    aws-c-mqtt: '>=0.15.2,<0.15.3.0a0'
+    aws-c-s3: '>=0.12.2,<0.12.3.0a0'
+    aws-checksums: '>=0.2.10,<0.2.11.0a0'
+    python: ''
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/awscrt-0.32.2-py313had5cc0f_0.conda
   hash:
-    md5: ac8f3c5a8e8e549e6ce9f599fb540324
-    sha256: 351724940bb515c3cffb497920d077a040b40b634b1fe1b365d3d6444070813f
+    md5: 48d466a7f0af93ca3f543c81ae59564a
+    sha256: c28719275944297e4c00e0a95741f6b99f1d6bba73fab17644213e673b2d41c4
   category: container
   optional: true
-- name: aws-crt-cpp
-  version: 0.40.1
+- name: awscrt
+  version: 0.32.2
   manager: conda
-  platform: linux-aarch64
+  platform: osx-arm64
   dependencies:
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    __osx: '>=11.0'
+    aws-c-auth: '>=0.10.1,<0.10.2.0a0'
+    aws-c-cal: '>=0.9.13,<0.9.14.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-event-stream: '>=0.7.0,<0.7.1.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-mqtt: '>=0.16.0,<0.16.1.0a0'
-    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-crt-cpp-0.40.1-h0495e26_1.conda
+    aws-c-mqtt: '>=0.15.2,<0.15.3.0a0'
+    aws-c-s3: '>=0.12.2,<0.12.3.0a0'
+    aws-checksums: '>=0.2.10,<0.2.11.0a0'
+    python: 3.13.*
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/awscrt-0.32.2-py313h09ebbf2_0.conda
   hash:
-    md5: ac8f3c5a8e8e549e6ce9f599fb540324
-    sha256: 351724940bb515c3cffb497920d077a040b40b634b1fe1b365d3d6444070813f
-  category: notebooks
-  optional: true
-- name: aws-crt-cpp
-  version: 0.40.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-mqtt: '>=0.16.0,<0.16.1.0a0'
-    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.40.1-h2224057_1.conda
-  hash:
-    md5: a6de3b44007e45268ea5728ea9fb0573
-    sha256: 37c0925b8e5bd904d51ef12c856934617dcf772c27e6a495891731e4a1e1782c
+    md5: ca657e0de5b71b2d3542086718536132
+    sha256: 29f3f077045090f3c6941d294c2b7c7a6371fcd1c7f043feac6adbfb1aafc038
   category: container
-  optional: true
-- name: aws-crt-cpp
-  version: 0.40.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-mqtt: '>=0.16.0,<0.16.1.0a0'
-    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.40.1-h2224057_1.conda
-  hash:
-    md5: a6de3b44007e45268ea5728ea9fb0573
-    sha256: 37c0925b8e5bd904d51ef12c856934617dcf772c27e6a495891731e4a1e1782c
-  category: notebooks
-  optional: true
-- name: aws-crt-cpp
-  version: 0.40.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-mqtt: '>=0.16.0,<0.16.1.0a0'
-    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.40.1-hb87031f_1.conda
-  hash:
-    md5: 602dd44df5dd28061de3ee798e991b42
-    sha256: 6d2b0bf67403c53f6954b7602e529cac91b1d156b22f71db5d97bf9ebc269790
-  category: container
-  optional: true
-- name: aws-crt-cpp
-  version: 0.40.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-cal: '>=0.9.14,<0.9.15.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-mqtt: '>=0.16.0,<0.16.1.0a0'
-    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.40.1-hb87031f_1.conda
-  hash:
-    md5: 602dd44df5dd28061de3ee798e991b42
-    sha256: 6d2b0bf67403c53f6954b7602e529cac91b1d156b22f71db5d97bf9ebc269790
-  category: notebooks
-  optional: true
-- name: aws-sdk-cpp
-  version: 1.11.747
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.747-hf4c7647_7.conda
-  hash:
-    md5: 6f597863865654f7c0b73dec9e10580d
-    sha256: ea7a0f2a1806be8aa9b3e9067d532de8d328fc8b27ecf6b1cb3bda3f74eb70df
-  category: container
-  optional: true
-- name: aws-sdk-cpp
-  version: 1.11.747
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.747-hf4c7647_7.conda
-  hash:
-    md5: 6f597863865654f7c0b73dec9e10580d
-    sha256: ea7a0f2a1806be8aa9b3e9067d532de8d328fc8b27ecf6b1cb3bda3f74eb70df
-  category: notebooks
-  optional: true
-- name: aws-sdk-cpp
-  version: 1.11.747
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.747-h6aa9b71_7.conda
-  hash:
-    md5: c365d649c7ed12d2877e7160b14bb2e0
-    sha256: 5aea253048953b5c735d9271110d8630207b9da121574f21c4c5151086c08872
-  category: container
-  optional: true
-- name: aws-sdk-cpp
-  version: 1.11.747
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.747-h6aa9b71_7.conda
-  hash:
-    md5: c365d649c7ed12d2877e7160b14bb2e0
-    sha256: 5aea253048953b5c735d9271110d8630207b9da121574f21c4c5151086c08872
-  category: notebooks
-  optional: true
-- name: aws-sdk-cpp
-  version: 1.11.747
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libcxx: '>=19'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.747-h18965b5_7.conda
-  hash:
-    md5: adce3b7ba7b9cd53b45f2a8cbbb274e3
-    sha256: 23841151832b57b74c951ec47e87a381644d33c886dc9d26e6fc22b037fda059
-  category: container
-  optional: true
-- name: aws-sdk-cpp
-  version: 1.11.747
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libcxx: '>=19'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.747-h18965b5_7.conda
-  hash:
-    md5: adce3b7ba7b9cd53b45f2a8cbbb274e3
-    sha256: 23841151832b57b74c951ec47e87a381644d33c886dc9d26e6fc22b037fda059
-  category: notebooks
-  optional: true
-- name: aws-sdk-cpp
-  version: 1.11.747
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libcxx: '>=19'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h4e95165_7.conda
-  hash:
-    md5: 28a22c86c0819985c291dbde9dbe548a
-    sha256: 48a47f63331523fdf56502ae2c820c56b9d83b576c71c980372825d179b5db65
-  category: container
-  optional: true
-- name: aws-sdk-cpp
-  version: 1.11.747
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libcxx: '>=19'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h4e95165_7.conda
-  hash:
-    md5: 28a22c86c0819985c291dbde9dbe548a
-    sha256: 48a47f63331523fdf56502ae2c820c56b9d83b576c71c980372825d179b5db65
-  category: notebooks
-  optional: true
-- name: azure-core-cpp
-  version: 1.16.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libcurl: '>=8.19.0,<9.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.16.3-h206d751_0.conda
-  hash:
-    md5: 0cabc152dc8896c3a4c4aebf2b308627
-    sha256: fffc66e9be8806a92b314e27129c42b1298ea7065028c9e5d175dacb07829261
-  category: container
-  optional: true
-- name: azure-core-cpp
-  version: 1.16.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libcurl: '>=8.19.0,<9.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.16.3-h206d751_0.conda
-  hash:
-    md5: 0cabc152dc8896c3a4c4aebf2b308627
-    sha256: fffc66e9be8806a92b314e27129c42b1298ea7065028c9e5d175dacb07829261
-  category: notebooks
-  optional: true
-- name: azure-core-cpp
-  version: 1.16.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libcurl: '>=8.19.0,<9.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-core-cpp-1.16.3-h412bcfc_0.conda
-  hash:
-    md5: eb4544865559667708a887e635b8f472
-    sha256: 5ba7676afdda3b325068e4da6192561acf4d11ce6352e86c20811043d71d5974
-  category: container
-  optional: true
-- name: azure-core-cpp
-  version: 1.16.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libcurl: '>=8.19.0,<9.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-core-cpp-1.16.3-h412bcfc_0.conda
-  hash:
-    md5: eb4544865559667708a887e635b8f472
-    sha256: 5ba7676afdda3b325068e4da6192561acf4d11ce6352e86c20811043d71d5974
-  category: notebooks
-  optional: true
-- name: azure-core-cpp
-  version: 1.16.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcurl: '>=8.19.0,<9.0a0'
-    libcxx: '>=19'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.16.3-hce1ca1b_0.conda
-  hash:
-    md5: c5e20566861a21ca9e671d0683540c47
-    sha256: f4587840df0e0b6356fc6d4c559d70a1641a7e1158c39fa1d20f0a06266edc14
-  category: container
-  optional: true
-- name: azure-core-cpp
-  version: 1.16.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcurl: '>=8.19.0,<9.0a0'
-    libcxx: '>=19'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.16.3-hce1ca1b_0.conda
-  hash:
-    md5: c5e20566861a21ca9e671d0683540c47
-    sha256: f4587840df0e0b6356fc6d4c559d70a1641a7e1158c39fa1d20f0a06266edc14
-  category: notebooks
-  optional: true
-- name: azure-core-cpp
-  version: 1.16.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcurl: '>=8.19.0,<9.0a0'
-    libcxx: '>=19'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.16.3-he5ae378_0.conda
-  hash:
-    md5: 4f42d997f42a8d34ff74cb677cf0c828
-    sha256: 9645073c4682ad3a334a2b06c5fc0ddc57fc9f0f537cc3123053634c92c28625
-  category: container
-  optional: true
-- name: azure-core-cpp
-  version: 1.16.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcurl: '>=8.19.0,<9.0a0'
-    libcxx: '>=19'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.16.3-he5ae378_0.conda
-  hash:
-    md5: 4f42d997f42a8d34ff74cb677cf0c828
-    sha256: 9645073c4682ad3a334a2b06c5fc0ddc57fc9f0f537cc3123053634c92c28625
-  category: notebooks
-  optional: true
-- name: azure-identity-cpp
-  version: 1.13.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.13.3-h71f81a8_2.conda
-  hash:
-    md5: f4fc754ec17176046988c46a54962a8c
-    sha256: ebca774f1ebaa24c150730603b418b33fc7862811a16d097716b1a29f34798c5
-  category: container
-  optional: true
-- name: azure-identity-cpp
-  version: 1.13.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.13.3-h71f81a8_2.conda
-  hash:
-    md5: f4fc754ec17176046988c46a54962a8c
-    sha256: ebca774f1ebaa24c150730603b418b33fc7862811a16d097716b1a29f34798c5
-  category: notebooks
-  optional: true
-- name: azure-identity-cpp
-  version: 1.13.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-identity-cpp-1.13.3-hd0001b6_2.conda
-  hash:
-    md5: c30d9e466e546970b50fbbcd335b60a0
-    sha256: cec5f8f1b866eae6f02110c5b4f2530c5ede3095b5e59431349f7352c8c1b1fb
-  category: container
-  optional: true
-- name: azure-identity-cpp
-  version: 1.13.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-identity-cpp-1.13.3-hd0001b6_2.conda
-  hash:
-    md5: c30d9e466e546970b50fbbcd335b60a0
-    sha256: cec5f8f1b866eae6f02110c5b4f2530c5ede3095b5e59431349f7352c8c1b1fb
-  category: notebooks
-  optional: true
-- name: azure-identity-cpp
-  version: 1.13.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    libcxx: '>=19'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.13.3-hfaa3f56_2.conda
-  hash:
-    md5: badbccafdb046acdcb95b2a076190a8b
-    sha256: dc8ac23b6a87f21c7e98fa7d4a4439ee049080e477ce4c0d1262aa5357662a75
-  category: container
-  optional: true
-- name: azure-identity-cpp
-  version: 1.13.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    libcxx: '>=19'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.13.3-hfaa3f56_2.conda
-  hash:
-    md5: badbccafdb046acdcb95b2a076190a8b
-    sha256: dc8ac23b6a87f21c7e98fa7d4a4439ee049080e477ce4c0d1262aa5357662a75
-  category: notebooks
-  optional: true
-- name: azure-identity-cpp
-  version: 1.13.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    libcxx: '>=19'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.13.3-h05177fb_2.conda
-  hash:
-    md5: e1701f6b2ce6f47aeb6cbfab132403d8
-    sha256: d950fb513311a15cd4ae663cdacb2c035122f609a9c790973661b38e0882e40e
-  category: container
-  optional: true
-- name: azure-identity-cpp
-  version: 1.13.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    libcxx: '>=19'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.13.3-h05177fb_2.conda
-  hash:
-    md5: e1701f6b2ce6f47aeb6cbfab132403d8
-    sha256: d950fb513311a15cd4ae663cdacb2c035122f609a9c790973661b38e0882e40e
-  category: notebooks
-  optional: true
-- name: azure-storage-blobs-cpp
-  version: 12.18.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-storage-common-cpp: '>=12.14.0,<12.14.1.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.18.0-h74b55db_1.conda
-  hash:
-    md5: 43151a3b0a8e037747d79a82dff9f967
-    sha256: 04bb27dbf1d426b4447b28c3dc92ec01c807fa784eea86ffa1f8c2bd9b9e8076
-  category: container
-  optional: true
-- name: azure-storage-blobs-cpp
-  version: 12.18.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-storage-common-cpp: '>=12.14.0,<12.14.1.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.18.0-h74b55db_1.conda
-  hash:
-    md5: 43151a3b0a8e037747d79a82dff9f967
-    sha256: 04bb27dbf1d426b4447b28c3dc92ec01c807fa784eea86ffa1f8c2bd9b9e8076
-  category: notebooks
-  optional: true
-- name: azure-storage-blobs-cpp
-  version: 12.18.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-storage-common-cpp: '>=12.14.0,<12.14.1.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-storage-blobs-cpp-12.18.0-h2e50874_1.conda
-  hash:
-    md5: 8de9d169d8ab02da10afbd2e2175282e
-    sha256: f9b95610e8432c8d419080d71038d396d50188dfa330e0e7d1402ff3dbd1cd87
-  category: container
-  optional: true
-- name: azure-storage-blobs-cpp
-  version: 12.18.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-storage-common-cpp: '>=12.14.0,<12.14.1.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-storage-blobs-cpp-12.18.0-h2e50874_1.conda
-  hash:
-    md5: 8de9d169d8ab02da10afbd2e2175282e
-    sha256: f9b95610e8432c8d419080d71038d396d50188dfa330e0e7d1402ff3dbd1cd87
-  category: notebooks
-  optional: true
-- name: azure-storage-blobs-cpp
-  version: 12.18.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-storage-common-cpp: '>=12.14.0,<12.14.1.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.18.0-h5a4125c_1.conda
-  hash:
-    md5: 8b47fe43c6469663d3ce511fe2f6eb0a
-    sha256: d6a9c98498d12545fb221885f8b02e06f6634871de169fbe7bc83517ee50bd47
-  category: container
-  optional: true
-- name: azure-storage-blobs-cpp
-  version: 12.18.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-storage-common-cpp: '>=12.14.0,<12.14.1.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.18.0-h5a4125c_1.conda
-  hash:
-    md5: 8b47fe43c6469663d3ce511fe2f6eb0a
-    sha256: d6a9c98498d12545fb221885f8b02e06f6634871de169fbe7bc83517ee50bd47
-  category: notebooks
-  optional: true
-- name: azure-storage-blobs-cpp
-  version: 12.18.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-storage-common-cpp: '>=12.14.0,<12.14.1.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.18.0-h409340b_1.conda
-  hash:
-    md5: 0948246cb8e514e4ae1cfe7dbb4046c7
-    sha256: 3f096d7cd6fd7788d57887c3d3e48be1ebc5c3a971666ddc0dd8a3493a5b7cb5
-  category: container
-  optional: true
-- name: azure-storage-blobs-cpp
-  version: 12.18.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-storage-common-cpp: '>=12.14.0,<12.14.1.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.18.0-h409340b_1.conda
-  hash:
-    md5: 0948246cb8e514e4ae1cfe7dbb4046c7
-    sha256: 3f096d7cd6fd7788d57887c3d3e48be1ebc5c3a971666ddc0dd8a3493a5b7cb5
-  category: notebooks
-  optional: true
-- name: azure-storage-common-cpp
-  version: 12.14.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libxml2: ''
-    libxml2-16: '>=2.14.6'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.14.0-hf596fc9_1.conda
-  hash:
-    md5: 7896f4a6ee78538e2d0261e3b36dfa69
-    sha256: 8a806f9852d280926d7613df548889b49e2a1c5d836385bcb2cedb24e7b08c64
-  category: container
-  optional: true
-- name: azure-storage-common-cpp
-  version: 12.14.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libxml2: ''
-    libxml2-16: '>=2.14.6'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.14.0-hf596fc9_1.conda
-  hash:
-    md5: 7896f4a6ee78538e2d0261e3b36dfa69
-    sha256: 8a806f9852d280926d7613df548889b49e2a1c5d836385bcb2cedb24e7b08c64
-  category: notebooks
-  optional: true
-- name: azure-storage-common-cpp
-  version: 12.14.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libxml2: ''
-    libxml2-16: '>=2.14.6'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-storage-common-cpp-12.14.0-hacd5e5f_1.conda
-  hash:
-    md5: 40cef89c86e33d5d58822827bd9e82a6
-    sha256: af2eb1e58bdfeaf1fded35625d20b5076191357d55350671ef7c18b34e44e277
-  category: container
-  optional: true
-- name: azure-storage-common-cpp
-  version: 12.14.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libxml2: ''
-    libxml2-16: '>=2.14.6'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-storage-common-cpp-12.14.0-hacd5e5f_1.conda
-  hash:
-    md5: 40cef89c86e33d5d58822827bd9e82a6
-    sha256: af2eb1e58bdfeaf1fded35625d20b5076191357d55350671ef7c18b34e44e277
-  category: notebooks
-  optional: true
-- name: azure-storage-common-cpp
-  version: 12.14.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    libcxx: '>=19'
-    libxml2: ''
-    libxml2-16: '>=2.14.6'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.14.0-hdf1104b_1.conda
-  hash:
-    md5: fbd5c8dd5c53c2c9b333e42d80a4cd81
-    sha256: bcccb30da57ae79387f7d3ab34e2c86cc458965f1307c347dabb56da5e5b51a6
-  category: container
-  optional: true
-- name: azure-storage-common-cpp
-  version: 12.14.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    libcxx: '>=19'
-    libxml2: ''
-    libxml2-16: '>=2.14.6'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.14.0-hdf1104b_1.conda
-  hash:
-    md5: fbd5c8dd5c53c2c9b333e42d80a4cd81
-    sha256: bcccb30da57ae79387f7d3ab34e2c86cc458965f1307c347dabb56da5e5b51a6
-  category: notebooks
-  optional: true
-- name: azure-storage-common-cpp
-  version: 12.14.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    libcxx: '>=19'
-    libxml2: ''
-    libxml2-16: '>=2.14.6'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.14.0-h7cba3ab_1.conda
-  hash:
-    md5: 2af5d1b5365c4a3de8ed8ec8438fe6ec
-    sha256: 9a1b6e5284f1f242330dfa1e21408ffd823a76df424108d8c319c2a46df61dba
-  category: container
-  optional: true
-- name: azure-storage-common-cpp
-  version: 12.14.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    libcxx: '>=19'
-    libxml2: ''
-    libxml2-16: '>=2.14.6'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.14.0-h7cba3ab_1.conda
-  hash:
-    md5: 2af5d1b5365c4a3de8ed8ec8438fe6ec
-    sha256: 9a1b6e5284f1f242330dfa1e21408ffd823a76df424108d8c319c2a46df61dba
-  category: notebooks
-  optional: true
-- name: azure-storage-files-datalake-cpp
-  version: 12.16.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
-    azure-storage-common-cpp: '>=12.14.0,<12.14.1.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.16.0-h1f05bef_1.conda
-  hash:
-    md5: 70972c9cb0893d6499dd4118415a966b
-    sha256: 13e2e6eb942f65bf81e9089bf6b5926534d9245c781288c5270beb3a25c9156b
-  category: container
-  optional: true
-- name: azure-storage-files-datalake-cpp
-  version: 12.16.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
-    azure-storage-common-cpp: '>=12.14.0,<12.14.1.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.16.0-h1f05bef_1.conda
-  hash:
-    md5: 70972c9cb0893d6499dd4118415a966b
-    sha256: 13e2e6eb942f65bf81e9089bf6b5926534d9245c781288c5270beb3a25c9156b
-  category: notebooks
-  optional: true
-- name: azure-storage-files-datalake-cpp
-  version: 12.16.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
-    azure-storage-common-cpp: '>=12.14.0,<12.14.1.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-storage-files-datalake-cpp-12.16.0-hde34f15_1.conda
-  hash:
-    md5: e8a075a1e6067cc8e59d7e408c284851
-    sha256: 10f09615e3c893f6848a8047a6f6644a6f0cab954a60337fbe96f8104aadc134
-  category: container
-  optional: true
-- name: azure-storage-files-datalake-cpp
-  version: 12.16.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
-    azure-storage-common-cpp: '>=12.14.0,<12.14.1.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-storage-files-datalake-cpp-12.16.0-hde34f15_1.conda
-  hash:
-    md5: e8a075a1e6067cc8e59d7e408c284851
-    sha256: 10f09615e3c893f6848a8047a6f6644a6f0cab954a60337fbe96f8104aadc134
-  category: notebooks
-  optional: true
-- name: azure-storage-files-datalake-cpp
-  version: 12.16.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
-    azure-storage-common-cpp: '>=12.14.0,<12.14.1.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.16.0-hf005220_1.conda
-  hash:
-    md5: 7426e418ab24c56c13e2938fe3b6d78c
-    sha256: 10da6321b84122c6c4454aca1da6fe4803116e92fc28c4928dee24da64c5284a
-  category: container
-  optional: true
-- name: azure-storage-files-datalake-cpp
-  version: 12.16.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
-    azure-storage-common-cpp: '>=12.14.0,<12.14.1.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.16.0-hf005220_1.conda
-  hash:
-    md5: 7426e418ab24c56c13e2938fe3b6d78c
-    sha256: 10da6321b84122c6c4454aca1da6fe4803116e92fc28c4928dee24da64c5284a
-  category: notebooks
-  optional: true
-- name: azure-storage-files-datalake-cpp
-  version: 12.16.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
-    azure-storage-common-cpp: '>=12.14.0,<12.14.1.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.16.0-h16bb3af_1.conda
-  hash:
-    md5: 06ba52b8a66fd041f4910b547e3f3da1
-    sha256: fb210d8d068df72a68c5fa655cf1f816792e278da3041c485478e7924d6e80eb
-  category: container
-  optional: true
-- name: azure-storage-files-datalake-cpp
-  version: 12.16.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
-    azure-storage-common-cpp: '>=12.14.0,<12.14.1.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.16.0-h16bb3af_1.conda
-  hash:
-    md5: 06ba52b8a66fd041f4910b547e3f3da1
-    sha256: fb210d8d068df72a68c5fa655cf1f816792e278da3041c485478e7924d6e80eb
-  category: notebooks
   optional: true
 - name: babel
   version: 2.18.0
@@ -3870,7 +2977,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
   hash:
     md5: f1976ce927373500cc19d3c0b2c85177
@@ -3882,7 +2989,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
   hash:
     md5: f1976ce927373500cc19d3c0b2c85177
@@ -3894,7 +3001,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
   hash:
     md5: f1976ce927373500cc19d3c0b2c85177
@@ -3906,7 +3013,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
   hash:
     md5: f1976ce927373500cc19d3c0b2c85177
@@ -3918,7 +3025,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
   hash:
     md5: f1976ce927373500cc19d3c0b2c85177
@@ -3930,7 +3037,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
   hash:
     md5: f1976ce927373500cc19d3c0b2c85177
@@ -3942,7 +3049,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
   hash:
     md5: f1976ce927373500cc19d3c0b2c85177
@@ -3954,7 +3061,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
   hash:
     md5: f1976ce927373500cc19d3c0b2c85177
@@ -3966,7 +3073,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
   hash:
     md5: f1976ce927373500cc19d3c0b2c85177
@@ -4040,7 +3147,7 @@ package:
   platform: linux-aarch64
   dependencies:
     backports: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
   hash:
     md5: bea46844deb274b2cc2a3a941745fa73
@@ -4053,7 +3160,7 @@ package:
   platform: osx-64
   dependencies:
     backports: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
   hash:
     md5: bea46844deb274b2cc2a3a941745fa73
@@ -4066,7 +3173,7 @@ package:
   platform: osx-arm64
   dependencies:
     backports: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
   hash:
     md5: bea46844deb274b2cc2a3a941745fa73
@@ -4606,60 +3713,6 @@ package:
     sha256: aed4b9dcf68ec2a75e5645fed14d77fd884d38d2e52bfa6ef4b278d90cd88781
   category: tools
   optional: true
-- name: blas
-  version: '2.308'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    blas-devel: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/blas-2.308-accelerate.conda
-  hash:
-    md5: a582beb68833329d7e4c930b9f928483
-    sha256: 4c77598ee85d65a1790fcb9a166e22f2550d4b36b58cb3d1bd0e4108a0a94266
-  category: notebooks
-  optional: true
-- name: blas
-  version: '2.308'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    blas-devel: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/blas-2.308-accelerate.conda
-  hash:
-    md5: 5fabdb9d144b1b88186d79df0ff6a02d
-    sha256: d9604b809048c3d0abfe42da6258e458d01348d42281f67203272bb8485d3049
-  category: notebooks
-  optional: true
-- name: blas-devel
-  version: 3.11.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libblas: 3.11.0
-    libcblas: 3.11.0
-    liblapack: 3.11.0
-    liblapacke: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/blas-devel-3.11.0-8_h83998a6_accelerate.conda
-  hash:
-    md5: ae1c26831adad0f6e708615a125a85ae
-    sha256: 8f49d55eb03d8bf3b032de5121aada5612278f46520323eb4bb2ff9ff690c2ee
-  category: notebooks
-  optional: true
-- name: blas-devel
-  version: 3.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libblas: 3.11.0
-    libcblas: 3.11.0
-    liblapack: 3.11.0
-    liblapacke: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/blas-devel-3.11.0-8_h55bc449_accelerate.conda
-  hash:
-    md5: 59223ab85a12ce4163b6cb1aa3357702
-    sha256: 8800834d25d4f9e3d2093b6f5d3672a9f6d9c65a1e8d79c9b110b672119564dd
-  category: notebooks
-  optional: true
 - name: bleach
   version: 6.4.0
   manager: conda
@@ -4691,7 +3744,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     webencodings: ''
   url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
   hash:
@@ -4704,7 +3757,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     webencodings: ''
   url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
   hash:
@@ -4717,7 +3770,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     webencodings: ''
   url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
   hash:
@@ -4730,7 +3783,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     webencodings: ''
   url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
   hash:
@@ -4743,7 +3796,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     webencodings: ''
   url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
   hash:
@@ -4756,7 +3809,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     webencodings: ''
   url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
   hash:
@@ -4983,174 +4036,6 @@ package:
   hash:
     md5: 925acfb50a750aa178f7a0aced77f351
     sha256: c3fe902114b9a3ac837e1a32408cc2142c147ec054c1038d37aec6814343f48a
-  category: notebooks
-  optional: true
-- name: bokeh
-  version: 3.9.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    contourpy: '>=1.2'
-    jinja2: '>=2.9'
-    narwhals: '>=1.13'
-    numpy: '>=1.16'
-    packaging: '>=16.8'
-    pillow: '>=7.1.0'
-    python: '>=3.10'
-    pyyaml: '>=3.10'
-    tornado: '>=6.2'
-    xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 123fcfe0df4b6fc21804538e59cdaafe
-    sha256: b3d3b93a17fa678e81cd5ff5309fe64c7feb65c71cb134f14e4fe2113dc0c8d5
-  category: container
-  optional: true
-- name: bokeh
-  version: 3.9.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    contourpy: '>=1.2'
-    jinja2: '>=2.9'
-    narwhals: '>=1.13'
-    numpy: '>=1.16'
-    packaging: '>=16.8'
-    pillow: '>=7.1.0'
-    python: '>=3.10'
-    pyyaml: '>=3.10'
-    tornado: '>=6.2'
-    xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 123fcfe0df4b6fc21804538e59cdaafe
-    sha256: b3d3b93a17fa678e81cd5ff5309fe64c7feb65c71cb134f14e4fe2113dc0c8d5
-  category: notebooks
-  optional: true
-- name: bokeh
-  version: 3.9.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    contourpy: '>=1.2'
-    jinja2: '>=2.9'
-    narwhals: '>=1.13'
-    numpy: '>=1.16'
-    packaging: '>=16.8'
-    pillow: '>=7.1.0'
-    python: '>=3.10'
-    pyyaml: '>=3.10'
-    tornado: '>=6.2'
-    xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 123fcfe0df4b6fc21804538e59cdaafe
-    sha256: b3d3b93a17fa678e81cd5ff5309fe64c7feb65c71cb134f14e4fe2113dc0c8d5
-  category: container
-  optional: true
-- name: bokeh
-  version: 3.9.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    contourpy: '>=1.2'
-    jinja2: '>=2.9'
-    narwhals: '>=1.13'
-    numpy: '>=1.16'
-    packaging: '>=16.8'
-    pillow: '>=7.1.0'
-    python: '>=3.10'
-    pyyaml: '>=3.10'
-    tornado: '>=6.2'
-    xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 123fcfe0df4b6fc21804538e59cdaafe
-    sha256: b3d3b93a17fa678e81cd5ff5309fe64c7feb65c71cb134f14e4fe2113dc0c8d5
-  category: notebooks
-  optional: true
-- name: bokeh
-  version: 3.9.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    contourpy: '>=1.2'
-    jinja2: '>=2.9'
-    narwhals: '>=1.13'
-    numpy: '>=1.16'
-    packaging: '>=16.8'
-    pillow: '>=7.1.0'
-    python: '>=3.10'
-    pyyaml: '>=3.10'
-    tornado: '>=6.2'
-    xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 123fcfe0df4b6fc21804538e59cdaafe
-    sha256: b3d3b93a17fa678e81cd5ff5309fe64c7feb65c71cb134f14e4fe2113dc0c8d5
-  category: container
-  optional: true
-- name: bokeh
-  version: 3.9.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    contourpy: '>=1.2'
-    jinja2: '>=2.9'
-    narwhals: '>=1.13'
-    numpy: '>=1.16'
-    packaging: '>=16.8'
-    pillow: '>=7.1.0'
-    python: '>=3.10'
-    pyyaml: '>=3.10'
-    tornado: '>=6.2'
-    xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 123fcfe0df4b6fc21804538e59cdaafe
-    sha256: b3d3b93a17fa678e81cd5ff5309fe64c7feb65c71cb134f14e4fe2113dc0c8d5
-  category: notebooks
-  optional: true
-- name: bokeh
-  version: 3.9.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    contourpy: '>=1.2'
-    jinja2: '>=2.9'
-    narwhals: '>=1.13'
-    numpy: '>=1.16'
-    packaging: '>=16.8'
-    pillow: '>=7.1.0'
-    python: '>=3.10'
-    pyyaml: '>=3.10'
-    tornado: '>=6.2'
-    xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 123fcfe0df4b6fc21804538e59cdaafe
-    sha256: b3d3b93a17fa678e81cd5ff5309fe64c7feb65c71cb134f14e4fe2113dc0c8d5
-  category: container
-  optional: true
-- name: bokeh
-  version: 3.9.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    contourpy: '>=1.2'
-    jinja2: '>=2.9'
-    narwhals: '>=1.13'
-    numpy: '>=1.16'
-    packaging: '>=16.8'
-    pillow: '>=7.1.0'
-    python: '>=3.10'
-    pyyaml: '>=3.10'
-    tornado: '>=6.2'
-    xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 123fcfe0df4b6fc21804538e59cdaafe
-    sha256: b3d3b93a17fa678e81cd5ff5309fe64c7feb65c71cb134f14e4fe2113dc0c8d5
   category: notebooks
   optional: true
 - name: boltons
@@ -5505,32 +4390,7 @@ package:
   hash:
     md5: 920bb03579f15389b9e512095ad995b7
     sha256: cc9accf72fa028d31c2a038460787751127317dcfa991f8d1f1babf216bb454e
-  category: container
-  optional: true
-- name: c-ares
-  version: 1.34.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
-  hash:
-    md5: 920bb03579f15389b9e512095ad995b7
-    sha256: cc9accf72fa028d31c2a038460787751127317dcfa991f8d1f1babf216bb454e
   category: notebooks
-  optional: true
-- name: c-ares
-  version: 1.34.6
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
-  hash:
-    md5: 1dfbec0d08f112103405756181304c16
-    sha256: 7ec8a68efe479e2e298558cbc2e79d29430d5c7508254268818c0ae19b206519
-  category: container
   optional: true
 - name: c-ares
   version: 1.34.6
@@ -5554,18 +4414,6 @@ package:
   hash:
     md5: fc9a153c57c9f070bebaa7eef30a8f17
     sha256: 2f5bc0292d595399df0d168355b4e9820affc8036792d6984bd751fdda2bcaea
-  category: container
-  optional: true
-- name: c-ares
-  version: 1.34.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
-  hash:
-    md5: fc9a153c57c9f070bebaa7eef30a8f17
-    sha256: 2f5bc0292d595399df0d168355b4e9820affc8036792d6984bd751fdda2bcaea
   category: notebooks
   optional: true
 - name: c-ares
@@ -5578,18 +4426,6 @@ package:
   hash:
     md5: bcb3cba70cf1eec964a03b4ba7775f01
     sha256: 2995f2aed4e53725e5efbc28199b46bf311c3cab2648fc4f10c2227d6d5fa196
-  category: container
-  optional: true
-- name: c-ares
-  version: 1.34.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
-  hash:
-    md5: bcb3cba70cf1eec964a03b4ba7775f01
-    sha256: 2995f2aed4e53725e5efbc28199b46bf311c3cab2648fc4f10c2227d6d5fa196
   category: notebooks
   optional: true
 - name: ca-certificates
@@ -5641,115 +4477,115 @@ package:
   category: main
   optional: false
 - name: cachecontrol
-  version: 0.14.3
+  version: 0.14.4
   manager: conda
   platform: linux-64
   dependencies:
     msgpack-python: '>=0.5.2,<2.0.0'
-    python: '>=3.9'
+    python: '>=3.10'
     requests: '>=2.16.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.3-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.4-pyha770c72_0.conda
   hash:
-    md5: 241ef6e3db47a143ac34c21bfba510f1
-    sha256: ec791bb6f1ef504411f87b28946a7ae63ed1f3681cefc462cf1dfdaf0790b6a9
+    md5: 13bdbb9b693b29134c56a9a00c23de41
+    sha256: cca3a26282a5bc37a10afb1aa2006a21c45033cbc4ff012f9501f56f2a115c12
   category: tools
   optional: true
 - name: cachecontrol
-  version: 0.14.3
+  version: 0.14.4
   manager: conda
   platform: linux-aarch64
   dependencies:
     msgpack-python: '>=0.5.2,<2.0.0'
-    python: '>=3.9'
+    python: '>=3.10'
     requests: '>=2.16.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.3-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.4-pyha770c72_0.conda
   hash:
-    md5: 241ef6e3db47a143ac34c21bfba510f1
-    sha256: ec791bb6f1ef504411f87b28946a7ae63ed1f3681cefc462cf1dfdaf0790b6a9
+    md5: 13bdbb9b693b29134c56a9a00c23de41
+    sha256: cca3a26282a5bc37a10afb1aa2006a21c45033cbc4ff012f9501f56f2a115c12
   category: tools
   optional: true
 - name: cachecontrol
-  version: 0.14.3
+  version: 0.14.4
   manager: conda
   platform: osx-64
   dependencies:
     msgpack-python: '>=0.5.2,<2.0.0'
-    python: '>=3.9'
+    python: '>=3.10'
     requests: '>=2.16.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.3-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.4-pyha770c72_0.conda
   hash:
-    md5: 241ef6e3db47a143ac34c21bfba510f1
-    sha256: ec791bb6f1ef504411f87b28946a7ae63ed1f3681cefc462cf1dfdaf0790b6a9
+    md5: 13bdbb9b693b29134c56a9a00c23de41
+    sha256: cca3a26282a5bc37a10afb1aa2006a21c45033cbc4ff012f9501f56f2a115c12
   category: tools
   optional: true
 - name: cachecontrol
-  version: 0.14.3
+  version: 0.14.4
   manager: conda
   platform: osx-arm64
   dependencies:
     msgpack-python: '>=0.5.2,<2.0.0'
-    python: '>=3.9'
+    python: '>=3.10'
     requests: '>=2.16.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.3-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.4-pyha770c72_0.conda
   hash:
-    md5: 241ef6e3db47a143ac34c21bfba510f1
-    sha256: ec791bb6f1ef504411f87b28946a7ae63ed1f3681cefc462cf1dfdaf0790b6a9
+    md5: 13bdbb9b693b29134c56a9a00c23de41
+    sha256: cca3a26282a5bc37a10afb1aa2006a21c45033cbc4ff012f9501f56f2a115c12
   category: tools
   optional: true
 - name: cachecontrol-with-filecache
-  version: 0.14.3
+  version: 0.14.4
   manager: conda
   platform: linux-64
   dependencies:
-    cachecontrol: 0.14.3
+    cachecontrol: 0.14.4
     filelock: '>=3.8.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.3-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.4-pyhd8ed1ab_0.conda
   hash:
-    md5: b4af8c1b61929b1bcb001c2953882149
-    sha256: 4ba4d08fba095556b7f1e06ec1dca068b367e68aadab0aca73115d02ddfcd518
+    md5: 41a7966424a8733b11410216d9a47227
+    sha256: becb375d64ebda9f9ed030d529b22da21030401d0dbaee62a208e60fca9c4587
   category: tools
   optional: true
 - name: cachecontrol-with-filecache
-  version: 0.14.3
+  version: 0.14.4
   manager: conda
   platform: linux-aarch64
   dependencies:
-    cachecontrol: 0.14.3
+    cachecontrol: 0.14.4
     filelock: '>=3.8.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.3-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.4-pyhd8ed1ab_0.conda
   hash:
-    md5: b4af8c1b61929b1bcb001c2953882149
-    sha256: 4ba4d08fba095556b7f1e06ec1dca068b367e68aadab0aca73115d02ddfcd518
+    md5: 41a7966424a8733b11410216d9a47227
+    sha256: becb375d64ebda9f9ed030d529b22da21030401d0dbaee62a208e60fca9c4587
   category: tools
   optional: true
 - name: cachecontrol-with-filecache
-  version: 0.14.3
+  version: 0.14.4
   manager: conda
   platform: osx-64
   dependencies:
-    cachecontrol: 0.14.3
+    cachecontrol: 0.14.4
     filelock: '>=3.8.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.3-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.4-pyhd8ed1ab_0.conda
   hash:
-    md5: b4af8c1b61929b1bcb001c2953882149
-    sha256: 4ba4d08fba095556b7f1e06ec1dca068b367e68aadab0aca73115d02ddfcd518
+    md5: 41a7966424a8733b11410216d9a47227
+    sha256: becb375d64ebda9f9ed030d529b22da21030401d0dbaee62a208e60fca9c4587
   category: tools
   optional: true
 - name: cachecontrol-with-filecache
-  version: 0.14.3
+  version: 0.14.4
   manager: conda
   platform: osx-arm64
   dependencies:
-    cachecontrol: 0.14.3
+    cachecontrol: 0.14.4
     filelock: '>=3.8.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.3-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.4-pyhd8ed1ab_0.conda
   hash:
-    md5: b4af8c1b61929b1bcb001c2953882149
-    sha256: 4ba4d08fba095556b7f1e06ec1dca068b367e68aadab0aca73115d02ddfcd518
+    md5: 41a7966424a8733b11410216d9a47227
+    sha256: becb375d64ebda9f9ed030d529b22da21030401d0dbaee62a208e60fca9c4587
   category: tools
   optional: true
 - name: cached-property
@@ -6155,7 +4991,7 @@ package:
   platform: linux-aarch64
   dependencies:
     cryptography: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/certipy-0.2.3-pyhcf101f3_0.conda
   hash:
     md5: 9d7f656740a8c0200e614b69ad8fccf9
@@ -6168,7 +5004,7 @@ package:
   platform: osx-64
   dependencies:
     cryptography: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/certipy-0.2.3-pyhcf101f3_0.conda
   hash:
     md5: 9d7f656740a8c0200e614b69ad8fccf9
@@ -6181,7 +5017,7 @@ package:
   platform: osx-arm64
   dependencies:
     cryptography: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/certipy-0.2.3-pyhcf101f3_0.conda
   hash:
     md5: 9d7f656740a8c0200e614b69ad8fccf9
@@ -6844,102 +5680,6 @@ package:
     sha256: cb7279eecddbd35ea78fd0e189a9a7db8b84c2c0e3b1271cf26251615f75dc4d
   category: tools
   optional: true
-- name: cloudpickle
-  version: 3.1.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
-  hash:
-    md5: 61b8078a0905b12529abc622406cb62c
-    sha256: 4c287c2721d8a34c94928be8fe0e9a85754e90189dd4384a31b1806856b50a67
-  category: container
-  optional: true
-- name: cloudpickle
-  version: 3.1.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
-  hash:
-    md5: 61b8078a0905b12529abc622406cb62c
-    sha256: 4c287c2721d8a34c94928be8fe0e9a85754e90189dd4384a31b1806856b50a67
-  category: notebooks
-  optional: true
-- name: cloudpickle
-  version: 3.1.2
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
-  hash:
-    md5: 61b8078a0905b12529abc622406cb62c
-    sha256: 4c287c2721d8a34c94928be8fe0e9a85754e90189dd4384a31b1806856b50a67
-  category: container
-  optional: true
-- name: cloudpickle
-  version: 3.1.2
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
-  hash:
-    md5: 61b8078a0905b12529abc622406cb62c
-    sha256: 4c287c2721d8a34c94928be8fe0e9a85754e90189dd4384a31b1806856b50a67
-  category: notebooks
-  optional: true
-- name: cloudpickle
-  version: 3.1.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
-  hash:
-    md5: 61b8078a0905b12529abc622406cb62c
-    sha256: 4c287c2721d8a34c94928be8fe0e9a85754e90189dd4384a31b1806856b50a67
-  category: container
-  optional: true
-- name: cloudpickle
-  version: 3.1.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
-  hash:
-    md5: 61b8078a0905b12529abc622406cb62c
-    sha256: 4c287c2721d8a34c94928be8fe0e9a85754e90189dd4384a31b1806856b50a67
-  category: notebooks
-  optional: true
-- name: cloudpickle
-  version: 3.1.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
-  hash:
-    md5: 61b8078a0905b12529abc622406cb62c
-    sha256: 4c287c2721d8a34c94928be8fe0e9a85754e90189dd4384a31b1806856b50a67
-  category: container
-  optional: true
-- name: cloudpickle
-  version: 3.1.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
-  hash:
-    md5: 61b8078a0905b12529abc622406cb62c
-    sha256: 4c287c2721d8a34c94928be8fe0e9a85754e90189dd4384a31b1806856b50a67
-  category: notebooks
-  optional: true
 - name: code-server
   version: 4.104.2
   manager: conda
@@ -7107,7 +5847,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
   hash:
     md5: 2da13f2b299d8e1995bafbbe9689a2f7
@@ -7119,7 +5859,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
   hash:
     md5: 2da13f2b299d8e1995bafbbe9689a2f7
@@ -7131,7 +5871,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
   hash:
     md5: 2da13f2b299d8e1995bafbbe9689a2f7
@@ -7143,7 +5883,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
   hash:
     md5: 2da13f2b299d8e1995bafbbe9689a2f7
@@ -7155,7 +5895,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
   hash:
     md5: 2da13f2b299d8e1995bafbbe9689a2f7
@@ -7167,7 +5907,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
   hash:
     md5: 2da13f2b299d8e1995bafbbe9689a2f7
@@ -7179,7 +5919,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
   hash:
     md5: 2da13f2b299d8e1995bafbbe9689a2f7
@@ -7191,7 +5931,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
   hash:
     md5: 2da13f2b299d8e1995bafbbe9689a2f7
@@ -7203,7 +5943,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
   hash:
     md5: 2da13f2b299d8e1995bafbbe9689a2f7
@@ -7281,7 +6021,7 @@ package:
     platformdirs: '>=3.10.0,<5.0.0'
     pydantic: '>=2'
     pyproject_hooks: '>=1.0.0,<2.0.0'
-    python: ''
+    python: '>=3.10'
     python-build: '>=1.2.1,<2.0.0'
     python-fastjsonschema: '>=2.18.0,<3.0.0'
     python-installer: '>=1.0.1,<2.0.0'
@@ -7328,7 +6068,7 @@ package:
     platformdirs: '>=3.10.0,<5.0.0'
     pydantic: '>=2'
     pyproject_hooks: '>=1.0.0,<2.0.0'
-    python: ''
+    python: '>=3.10'
     python-build: '>=1.2.1,<2.0.0'
     python-fastjsonschema: '>=2.18.0,<3.0.0'
     python-installer: '>=1.0.1,<2.0.0'
@@ -7376,7 +6116,7 @@ package:
     platformdirs: '>=3.10.0,<5.0.0'
     pydantic: '>=2'
     pyproject_hooks: '>=1.0.0,<2.0.0'
-    python: ''
+    python: '>=3.10'
     python-build: '>=1.2.1,<2.0.0'
     python-fastjsonschema: '>=2.18.0,<3.0.0'
     python-installer: '>=1.0.1,<2.0.0'
@@ -7451,136 +6191,6 @@ package:
     md5: b4e3dcace82b486f69bc693f30120205
     sha256: af3b666ea6043a146901cd151d6201126bbe19af8307b58fb175015e3710064c
   category: tools
-  optional: true
-- name: contourpy
-  version: 1.3.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    numpy: '>=1.25'
-    python: ''
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py313hc8edb43_4.conda
-  hash:
-    md5: 33639459bc29437315d4bff9ed5bc7a7
-    sha256: 7f86eb205d2d7fcf2c82654a08c6a240623ac34cb406206b4b1f1afa5cda8e49
-  category: container
-  optional: true
-- name: contourpy
-  version: 1.3.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    numpy: '>=1.25'
-    python: ''
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py313hc8edb43_4.conda
-  hash:
-    md5: 33639459bc29437315d4bff9ed5bc7a7
-    sha256: 7f86eb205d2d7fcf2c82654a08c6a240623ac34cb406206b4b1f1afa5cda8e49
-  category: notebooks
-  optional: true
-- name: contourpy
-  version: 1.3.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    numpy: '>=1.25'
-    python: 3.13.*
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/contourpy-1.3.3-py313h75bc965_4.conda
-  hash:
-    md5: e0ca534fbf414d1a05bbb8dec094dd1d
-    sha256: 970a8dadfeae15639136a046dfbb44711425b04a0660f99162887f444f7cc9e2
-  category: container
-  optional: true
-- name: contourpy
-  version: 1.3.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    numpy: '>=1.25'
-    python: 3.13.*
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/contourpy-1.3.3-py313h75bc965_4.conda
-  hash:
-    md5: e0ca534fbf414d1a05bbb8dec094dd1d
-    sha256: 970a8dadfeae15639136a046dfbb44711425b04a0660f99162887f444f7cc9e2
-  category: notebooks
-  optional: true
-- name: contourpy
-  version: 1.3.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=19'
-    numpy: '>=1.25'
-    python: ''
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.3-py313h98b818e_4.conda
-  hash:
-    md5: 24c06ae9a202f16555c5a1f8006a0bd7
-    sha256: bb5ae30df17e054668717b46c2053534a8a7d1bc94aedb8d6d22917c59eaa63c
-  category: container
-  optional: true
-- name: contourpy
-  version: 1.3.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=19'
-    numpy: '>=1.25'
-    python: ''
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.3-py313h98b818e_4.conda
-  hash:
-    md5: 24c06ae9a202f16555c5a1f8006a0bd7
-    sha256: bb5ae30df17e054668717b46c2053534a8a7d1bc94aedb8d6d22917c59eaa63c
-  category: notebooks
-  optional: true
-- name: contourpy
-  version: 1.3.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    numpy: '>=1.25'
-    python: 3.13.*
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.3-py313h2af2deb_4.conda
-  hash:
-    md5: afd3e394d14e627be0de6e8ee3553dae
-    sha256: 6320cd6c16fdcf25efa493f9a2c54b2687911967a5e90544d599c535535387e9
-  category: container
-  optional: true
-- name: contourpy
-  version: 1.3.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    numpy: '>=1.25'
-    python: 3.13.*
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.3-py313h2af2deb_4.conda
-  hash:
-    md5: afd3e394d14e627be0de6e8ee3553dae
-    sha256: 6320cd6c16fdcf25efa493f9a2c54b2687911967a5e90544d599c535535387e9
-  category: notebooks
   optional: true
 - name: cpython
   version: 3.13.14
@@ -7967,456 +6577,6 @@ package:
     md5: fcafa4ea64298701d582b0bd697592be
     sha256: aa94e10d98ce59815319fd7ef35be3b847778a5e9a164ee9663314ece832caaa
   category: tools
-  optional: true
-- name: cytoolz
-  version: 1.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-    toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.1.0-py313h07c4f96_2.conda
-  hash:
-    md5: 7e7e3c5a8a28c6b8eb430183e0554adf
-    sha256: fd33f531288fb08afef72a65414d29caefbba31cb398533534794475af35b1b3
-  category: container
-  optional: true
-- name: cytoolz
-  version: 1.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-    toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.1.0-py313h07c4f96_2.conda
-  hash:
-    md5: 7e7e3c5a8a28c6b8eb430183e0554adf
-    sha256: fd33f531288fb08afef72a65414d29caefbba31cb398533534794475af35b1b3
-  category: notebooks
-  optional: true
-- name: cytoolz
-  version: 1.1.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-    toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cytoolz-1.1.0-py313he149459_2.conda
-  hash:
-    md5: 3c05236bd38cdf06c9fb90e36e27adff
-    sha256: 42db998d6eec4f4585356eec3cb3006a09696c67149c92fb2cf7ee8c5613fcc9
-  category: container
-  optional: true
-- name: cytoolz
-  version: 1.1.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-    toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cytoolz-1.1.0-py313he149459_2.conda
-  hash:
-    md5: 3c05236bd38cdf06c9fb90e36e27adff
-    sha256: 42db998d6eec4f4585356eec3cb3006a09696c67149c92fb2cf7ee8c5613fcc9
-  category: notebooks
-  optional: true
-- name: cytoolz
-  version: 1.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-    toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.1.0-py313h36bb7f5_2.conda
-  hash:
-    md5: bdeebe589a7c1d098f7db85f2d03604a
-    sha256: f88f35acd597f275f83a16fa0d370f439206ae310bf028fd90ec242cecb2e8ed
-  category: container
-  optional: true
-- name: cytoolz
-  version: 1.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-    toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.1.0-py313h36bb7f5_2.conda
-  hash:
-    md5: bdeebe589a7c1d098f7db85f2d03604a
-    sha256: f88f35acd597f275f83a16fa0d370f439206ae310bf028fd90ec242cecb2e8ed
-  category: notebooks
-  optional: true
-- name: cytoolz
-  version: 1.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-    toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.1.0-py313h0997733_2.conda
-  hash:
-    md5: 5b7dd41f7974dd5d52bf37cbc0322e84
-    sha256: d272fa92cbf6b4de83a47702878e1ac75efc665d7f60f1c2818c8c33ebd4cfa6
-  category: container
-  optional: true
-- name: cytoolz
-  version: 1.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-    toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.1.0-py313h0997733_2.conda
-  hash:
-    md5: 5b7dd41f7974dd5d52bf37cbc0322e84
-    sha256: d272fa92cbf6b4de83a47702878e1ac75efc665d7f60f1c2818c8c33ebd4cfa6
-  category: notebooks
-  optional: true
-- name: dask
-  version: 2026.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    bokeh: '>=3.1.0'
-    cytoolz: '>=0.11.2'
-    dask-core: '>=2026.6.0,<2026.6.1.0a0'
-    distributed: '>=2026.6.0,<2026.6.1.0a0'
-    jinja2: '>=2.10.3'
-    lz4: '>=4.3.2'
-    numpy: '>=1.26'
-    pandas: '>=2.0'
-    pyarrow: '>=16.0'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2026.6.0-pyhc364b38_0.conda
-  hash:
-    md5: a2d2a05abf6076c3d041ec91b2235823
-    sha256: 2ada45db64509bc5c119cbd7d68953b5ec7a9341cc9fad7cbe6a4f029e8af0fb
-  category: container
-  optional: true
-- name: dask
-  version: 2026.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    bokeh: '>=3.1.0'
-    cytoolz: '>=0.11.2'
-    dask-core: '>=2026.6.0,<2026.6.1.0a0'
-    distributed: '>=2026.6.0,<2026.6.1.0a0'
-    jinja2: '>=2.10.3'
-    lz4: '>=4.3.2'
-    numpy: '>=1.26'
-    pandas: '>=2.0'
-    pyarrow: '>=16.0'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2026.6.0-pyhc364b38_0.conda
-  hash:
-    md5: a2d2a05abf6076c3d041ec91b2235823
-    sha256: 2ada45db64509bc5c119cbd7d68953b5ec7a9341cc9fad7cbe6a4f029e8af0fb
-  category: notebooks
-  optional: true
-- name: dask
-  version: 2026.6.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    bokeh: '>=3.1.0'
-    cytoolz: '>=0.11.2'
-    dask-core: '>=2026.6.0,<2026.6.1.0a0'
-    distributed: '>=2026.6.0,<2026.6.1.0a0'
-    jinja2: '>=2.10.3'
-    lz4: '>=4.3.2'
-    numpy: '>=1.26'
-    pandas: '>=2.0'
-    pyarrow: '>=16.0'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2026.6.0-pyhc364b38_0.conda
-  hash:
-    md5: a2d2a05abf6076c3d041ec91b2235823
-    sha256: 2ada45db64509bc5c119cbd7d68953b5ec7a9341cc9fad7cbe6a4f029e8af0fb
-  category: container
-  optional: true
-- name: dask
-  version: 2026.6.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    bokeh: '>=3.1.0'
-    cytoolz: '>=0.11.2'
-    dask-core: '>=2026.6.0,<2026.6.1.0a0'
-    distributed: '>=2026.6.0,<2026.6.1.0a0'
-    jinja2: '>=2.10.3'
-    lz4: '>=4.3.2'
-    numpy: '>=1.26'
-    pandas: '>=2.0'
-    pyarrow: '>=16.0'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2026.6.0-pyhc364b38_0.conda
-  hash:
-    md5: a2d2a05abf6076c3d041ec91b2235823
-    sha256: 2ada45db64509bc5c119cbd7d68953b5ec7a9341cc9fad7cbe6a4f029e8af0fb
-  category: notebooks
-  optional: true
-- name: dask
-  version: 2026.6.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    bokeh: '>=3.1.0'
-    cytoolz: '>=0.11.2'
-    dask-core: '>=2026.6.0,<2026.6.1.0a0'
-    distributed: '>=2026.6.0,<2026.6.1.0a0'
-    jinja2: '>=2.10.3'
-    lz4: '>=4.3.2'
-    numpy: '>=1.26'
-    pandas: '>=2.0'
-    pyarrow: '>=16.0'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2026.6.0-pyhc364b38_0.conda
-  hash:
-    md5: a2d2a05abf6076c3d041ec91b2235823
-    sha256: 2ada45db64509bc5c119cbd7d68953b5ec7a9341cc9fad7cbe6a4f029e8af0fb
-  category: container
-  optional: true
-- name: dask
-  version: 2026.6.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    bokeh: '>=3.1.0'
-    cytoolz: '>=0.11.2'
-    dask-core: '>=2026.6.0,<2026.6.1.0a0'
-    distributed: '>=2026.6.0,<2026.6.1.0a0'
-    jinja2: '>=2.10.3'
-    lz4: '>=4.3.2'
-    numpy: '>=1.26'
-    pandas: '>=2.0'
-    pyarrow: '>=16.0'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2026.6.0-pyhc364b38_0.conda
-  hash:
-    md5: a2d2a05abf6076c3d041ec91b2235823
-    sha256: 2ada45db64509bc5c119cbd7d68953b5ec7a9341cc9fad7cbe6a4f029e8af0fb
-  category: notebooks
-  optional: true
-- name: dask
-  version: 2026.6.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    bokeh: '>=3.1.0'
-    cytoolz: '>=0.11.2'
-    dask-core: '>=2026.6.0,<2026.6.1.0a0'
-    distributed: '>=2026.6.0,<2026.6.1.0a0'
-    jinja2: '>=2.10.3'
-    lz4: '>=4.3.2'
-    numpy: '>=1.26'
-    pandas: '>=2.0'
-    pyarrow: '>=16.0'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2026.6.0-pyhc364b38_0.conda
-  hash:
-    md5: a2d2a05abf6076c3d041ec91b2235823
-    sha256: 2ada45db64509bc5c119cbd7d68953b5ec7a9341cc9fad7cbe6a4f029e8af0fb
-  category: container
-  optional: true
-- name: dask
-  version: 2026.6.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    bokeh: '>=3.1.0'
-    cytoolz: '>=0.11.2'
-    dask-core: '>=2026.6.0,<2026.6.1.0a0'
-    distributed: '>=2026.6.0,<2026.6.1.0a0'
-    jinja2: '>=2.10.3'
-    lz4: '>=4.3.2'
-    numpy: '>=1.26'
-    pandas: '>=2.0'
-    pyarrow: '>=16.0'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2026.6.0-pyhc364b38_0.conda
-  hash:
-    md5: a2d2a05abf6076c3d041ec91b2235823
-    sha256: 2ada45db64509bc5c119cbd7d68953b5ec7a9341cc9fad7cbe6a4f029e8af0fb
-  category: notebooks
-  optional: true
-- name: dask-core
-  version: 2026.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    click: '>=8.1'
-    cloudpickle: '>=3.0.0'
-    fsspec: '>=2021.9.0'
-    importlib-metadata: '>=4.13.0'
-    packaging: '>=20.0'
-    partd: '>=1.4.0'
-    python: ''
-    pyyaml: '>=5.4.1'
-    toolz: '>=0.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2026.6.0-pyhc364b38_0.conda
-  hash:
-    md5: 56a3cae23de84509452da890fb2bfd85
-    sha256: ce64f55e95912bff84119f05a296c90f8df57ecf9c3100bd8a6beca1cedabbb7
-  category: container
-  optional: true
-- name: dask-core
-  version: 2026.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    click: '>=8.1'
-    cloudpickle: '>=3.0.0'
-    fsspec: '>=2021.9.0'
-    importlib-metadata: '>=4.13.0'
-    packaging: '>=20.0'
-    partd: '>=1.4.0'
-    python: ''
-    pyyaml: '>=5.4.1'
-    toolz: '>=0.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2026.6.0-pyhc364b38_0.conda
-  hash:
-    md5: 56a3cae23de84509452da890fb2bfd85
-    sha256: ce64f55e95912bff84119f05a296c90f8df57ecf9c3100bd8a6beca1cedabbb7
-  category: notebooks
-  optional: true
-- name: dask-core
-  version: 2026.6.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    click: '>=8.1'
-    cloudpickle: '>=3.0.0'
-    fsspec: '>=2021.9.0'
-    importlib-metadata: '>=4.13.0'
-    packaging: '>=20.0'
-    partd: '>=1.4.0'
-    python: ''
-    pyyaml: '>=5.4.1'
-    toolz: '>=0.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2026.6.0-pyhc364b38_0.conda
-  hash:
-    md5: 56a3cae23de84509452da890fb2bfd85
-    sha256: ce64f55e95912bff84119f05a296c90f8df57ecf9c3100bd8a6beca1cedabbb7
-  category: container
-  optional: true
-- name: dask-core
-  version: 2026.6.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    click: '>=8.1'
-    cloudpickle: '>=3.0.0'
-    fsspec: '>=2021.9.0'
-    importlib-metadata: '>=4.13.0'
-    packaging: '>=20.0'
-    partd: '>=1.4.0'
-    python: ''
-    pyyaml: '>=5.4.1'
-    toolz: '>=0.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2026.6.0-pyhc364b38_0.conda
-  hash:
-    md5: 56a3cae23de84509452da890fb2bfd85
-    sha256: ce64f55e95912bff84119f05a296c90f8df57ecf9c3100bd8a6beca1cedabbb7
-  category: notebooks
-  optional: true
-- name: dask-core
-  version: 2026.6.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    click: '>=8.1'
-    cloudpickle: '>=3.0.0'
-    fsspec: '>=2021.9.0'
-    importlib-metadata: '>=4.13.0'
-    packaging: '>=20.0'
-    partd: '>=1.4.0'
-    python: ''
-    pyyaml: '>=5.4.1'
-    toolz: '>=0.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2026.6.0-pyhc364b38_0.conda
-  hash:
-    md5: 56a3cae23de84509452da890fb2bfd85
-    sha256: ce64f55e95912bff84119f05a296c90f8df57ecf9c3100bd8a6beca1cedabbb7
-  category: container
-  optional: true
-- name: dask-core
-  version: 2026.6.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    click: '>=8.1'
-    cloudpickle: '>=3.0.0'
-    fsspec: '>=2021.9.0'
-    importlib-metadata: '>=4.13.0'
-    packaging: '>=20.0'
-    partd: '>=1.4.0'
-    python: ''
-    pyyaml: '>=5.4.1'
-    toolz: '>=0.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2026.6.0-pyhc364b38_0.conda
-  hash:
-    md5: 56a3cae23de84509452da890fb2bfd85
-    sha256: ce64f55e95912bff84119f05a296c90f8df57ecf9c3100bd8a6beca1cedabbb7
-  category: notebooks
-  optional: true
-- name: dask-core
-  version: 2026.6.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    click: '>=8.1'
-    cloudpickle: '>=3.0.0'
-    fsspec: '>=2021.9.0'
-    importlib-metadata: '>=4.13.0'
-    packaging: '>=20.0'
-    partd: '>=1.4.0'
-    python: ''
-    pyyaml: '>=5.4.1'
-    toolz: '>=0.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2026.6.0-pyhc364b38_0.conda
-  hash:
-    md5: 56a3cae23de84509452da890fb2bfd85
-    sha256: ce64f55e95912bff84119f05a296c90f8df57ecf9c3100bd8a6beca1cedabbb7
-  category: container
-  optional: true
-- name: dask-core
-  version: 2026.6.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    click: '>=8.1'
-    cloudpickle: '>=3.0.0'
-    fsspec: '>=2021.9.0'
-    importlib-metadata: '>=4.13.0'
-    packaging: '>=20.0'
-    partd: '>=1.4.0'
-    python: ''
-    pyyaml: '>=5.4.1'
-    toolz: '>=0.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2026.6.0-pyhc364b38_0.conda
-  hash:
-    md5: 56a3cae23de84509452da890fb2bfd85
-    sha256: ce64f55e95912bff84119f05a296c90f8df57ecf9c3100bd8a6beca1cedabbb7
-  category: notebooks
   optional: true
 - name: dbus
   version: 1.16.2
@@ -8939,7 +7099,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.3-pyhcf101f3_0.conda
   hash:
     md5: 58638f77697c4f6726753eb8be34818b
@@ -8951,7 +7111,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.3-pyhcf101f3_0.conda
   hash:
     md5: 58638f77697c4f6726753eb8be34818b
@@ -8963,228 +7123,212 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.3-pyhcf101f3_0.conda
   hash:
     md5: 58638f77697c4f6726753eb8be34818b
     sha256: e2753997b8bd34205f42be01b8bab8037423dc30c02a1ec12de23e5b4c0b0a2e
   category: tools
   optional: true
-- name: distributed
-  version: 2026.6.0
+- name: distro
+  version: 1.8.0
   manager: conda
   platform: linux-64
   dependencies:
-    click: '>=8.0'
-    cloudpickle: '>=3.0.0'
-    cytoolz: '>=0.12.0'
-    dask-core: '>=2026.6.0,<2026.6.1.0a0'
-    jinja2: '>=2.10.3'
-    locket: '>=1.0.0'
-    msgpack-python: '>=1.0.2'
-    packaging: '>=20.0'
-    psutil: '>=5.8.0'
-    python: ''
-    pyyaml: '>=5.4.1'
-    sortedcontainers: '>=2.0.5'
-    tblib: '>=1.6.0'
-    toolz: '>=0.12.0'
-    tornado: '>=6.2.0'
-    zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.6.0-pyhc364b38_1.conda
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2a6851a6c69ce7c0b03a89d5d4209257
-    sha256: 2386b3b1dabe713b46d46c21758e03bc2c080a784fdd225f46c20b3b7e45c854
+    md5: 67999c5465064480fa8016d00ac768f6
+    sha256: 0d01c4da6d4f0a935599210f82ac0630fa9aeb4fc37cbbc78043a932a39ec4f3
   category: container
   optional: true
-- name: distributed
-  version: 2026.6.0
+- name: distro
+  version: 1.8.0
   manager: conda
   platform: linux-64
   dependencies:
-    click: '>=8.0'
-    cloudpickle: '>=3.0.0'
-    cytoolz: '>=0.12.0'
-    dask-core: '>=2026.6.0,<2026.6.1.0a0'
-    jinja2: '>=2.10.3'
-    locket: '>=1.0.0'
-    msgpack-python: '>=1.0.2'
-    packaging: '>=20.0'
-    psutil: '>=5.8.0'
-    python: ''
-    pyyaml: '>=5.4.1'
-    sortedcontainers: '>=2.0.5'
-    tblib: '>=1.6.0'
-    toolz: '>=0.12.0'
-    tornado: '>=6.2.0'
-    zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.6.0-pyhc364b38_1.conda
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2a6851a6c69ce7c0b03a89d5d4209257
-    sha256: 2386b3b1dabe713b46d46c21758e03bc2c080a784fdd225f46c20b3b7e45c854
-  category: notebooks
+    md5: 67999c5465064480fa8016d00ac768f6
+    sha256: 0d01c4da6d4f0a935599210f82ac0630fa9aeb4fc37cbbc78043a932a39ec4f3
+  category: tools
   optional: true
-- name: distributed
-  version: 2026.6.0
+- name: distro
+  version: 1.8.0
   manager: conda
   platform: linux-aarch64
   dependencies:
-    click: '>=8.0'
-    cloudpickle: '>=3.0.0'
-    cytoolz: '>=0.12.0'
-    dask-core: '>=2026.6.0,<2026.6.1.0a0'
-    jinja2: '>=2.10.3'
-    locket: '>=1.0.0'
-    msgpack-python: '>=1.0.2'
-    packaging: '>=20.0'
-    psutil: '>=5.8.0'
-    python: ''
-    pyyaml: '>=5.4.1'
-    sortedcontainers: '>=2.0.5'
-    tblib: '>=1.6.0'
-    toolz: '>=0.12.0'
-    tornado: '>=6.2.0'
-    zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.6.0-pyhc364b38_1.conda
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2a6851a6c69ce7c0b03a89d5d4209257
-    sha256: 2386b3b1dabe713b46d46c21758e03bc2c080a784fdd225f46c20b3b7e45c854
+    md5: 67999c5465064480fa8016d00ac768f6
+    sha256: 0d01c4da6d4f0a935599210f82ac0630fa9aeb4fc37cbbc78043a932a39ec4f3
   category: container
   optional: true
-- name: distributed
-  version: 2026.6.0
+- name: distro
+  version: 1.8.0
   manager: conda
   platform: linux-aarch64
   dependencies:
-    click: '>=8.0'
-    cloudpickle: '>=3.0.0'
-    cytoolz: '>=0.12.0'
-    dask-core: '>=2026.6.0,<2026.6.1.0a0'
-    jinja2: '>=2.10.3'
-    locket: '>=1.0.0'
-    msgpack-python: '>=1.0.2'
-    packaging: '>=20.0'
-    psutil: '>=5.8.0'
-    python: ''
-    pyyaml: '>=5.4.1'
-    sortedcontainers: '>=2.0.5'
-    tblib: '>=1.6.0'
-    toolz: '>=0.12.0'
-    tornado: '>=6.2.0'
-    zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.6.0-pyhc364b38_1.conda
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2a6851a6c69ce7c0b03a89d5d4209257
-    sha256: 2386b3b1dabe713b46d46c21758e03bc2c080a784fdd225f46c20b3b7e45c854
-  category: notebooks
+    md5: 67999c5465064480fa8016d00ac768f6
+    sha256: 0d01c4da6d4f0a935599210f82ac0630fa9aeb4fc37cbbc78043a932a39ec4f3
+  category: tools
   optional: true
-- name: distributed
-  version: 2026.6.0
+- name: distro
+  version: 1.8.0
   manager: conda
   platform: osx-64
   dependencies:
-    click: '>=8.0'
-    cloudpickle: '>=3.0.0'
-    cytoolz: '>=0.12.0'
-    dask-core: '>=2026.6.0,<2026.6.1.0a0'
-    jinja2: '>=2.10.3'
-    locket: '>=1.0.0'
-    msgpack-python: '>=1.0.2'
-    packaging: '>=20.0'
-    psutil: '>=5.8.0'
-    python: ''
-    pyyaml: '>=5.4.1'
-    sortedcontainers: '>=2.0.5'
-    tblib: '>=1.6.0'
-    toolz: '>=0.12.0'
-    tornado: '>=6.2.0'
-    zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.6.0-pyhc364b38_1.conda
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2a6851a6c69ce7c0b03a89d5d4209257
-    sha256: 2386b3b1dabe713b46d46c21758e03bc2c080a784fdd225f46c20b3b7e45c854
+    md5: 67999c5465064480fa8016d00ac768f6
+    sha256: 0d01c4da6d4f0a935599210f82ac0630fa9aeb4fc37cbbc78043a932a39ec4f3
   category: container
   optional: true
-- name: distributed
-  version: 2026.6.0
+- name: distro
+  version: 1.8.0
   manager: conda
   platform: osx-64
   dependencies:
-    click: '>=8.0'
-    cloudpickle: '>=3.0.0'
-    cytoolz: '>=0.12.0'
-    dask-core: '>=2026.6.0,<2026.6.1.0a0'
-    jinja2: '>=2.10.3'
-    locket: '>=1.0.0'
-    msgpack-python: '>=1.0.2'
-    packaging: '>=20.0'
-    psutil: '>=5.8.0'
-    python: ''
-    pyyaml: '>=5.4.1'
-    sortedcontainers: '>=2.0.5'
-    tblib: '>=1.6.0'
-    toolz: '>=0.12.0'
-    tornado: '>=6.2.0'
-    zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.6.0-pyhc364b38_1.conda
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2a6851a6c69ce7c0b03a89d5d4209257
-    sha256: 2386b3b1dabe713b46d46c21758e03bc2c080a784fdd225f46c20b3b7e45c854
-  category: notebooks
+    md5: 67999c5465064480fa8016d00ac768f6
+    sha256: 0d01c4da6d4f0a935599210f82ac0630fa9aeb4fc37cbbc78043a932a39ec4f3
+  category: tools
   optional: true
-- name: distributed
-  version: 2026.6.0
+- name: distro
+  version: 1.8.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    click: '>=8.0'
-    cloudpickle: '>=3.0.0'
-    cytoolz: '>=0.12.0'
-    dask-core: '>=2026.6.0,<2026.6.1.0a0'
-    jinja2: '>=2.10.3'
-    locket: '>=1.0.0'
-    msgpack-python: '>=1.0.2'
-    packaging: '>=20.0'
-    psutil: '>=5.8.0'
-    python: ''
-    pyyaml: '>=5.4.1'
-    sortedcontainers: '>=2.0.5'
-    tblib: '>=1.6.0'
-    toolz: '>=0.12.0'
-    tornado: '>=6.2.0'
-    zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.6.0-pyhc364b38_1.conda
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2a6851a6c69ce7c0b03a89d5d4209257
-    sha256: 2386b3b1dabe713b46d46c21758e03bc2c080a784fdd225f46c20b3b7e45c854
+    md5: 67999c5465064480fa8016d00ac768f6
+    sha256: 0d01c4da6d4f0a935599210f82ac0630fa9aeb4fc37cbbc78043a932a39ec4f3
   category: container
   optional: true
-- name: distributed
-  version: 2026.6.0
+- name: distro
+  version: 1.8.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    click: '>=8.0'
-    cloudpickle: '>=3.0.0'
-    cytoolz: '>=0.12.0'
-    dask-core: '>=2026.6.0,<2026.6.1.0a0'
-    jinja2: '>=2.10.3'
-    locket: '>=1.0.0'
-    msgpack-python: '>=1.0.2'
-    packaging: '>=20.0'
-    psutil: '>=5.8.0'
-    python: ''
-    pyyaml: '>=5.4.1'
-    sortedcontainers: '>=2.0.5'
-    tblib: '>=1.6.0'
-    toolz: '>=0.12.0'
-    tornado: '>=6.2.0'
-    zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.6.0-pyhc364b38_1.conda
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2a6851a6c69ce7c0b03a89d5d4209257
-    sha256: 2386b3b1dabe713b46d46c21758e03bc2c080a784fdd225f46c20b3b7e45c854
-  category: notebooks
+    md5: 67999c5465064480fa8016d00ac768f6
+    sha256: 0d01c4da6d4f0a935599210f82ac0630fa9aeb4fc37cbbc78043a932a39ec4f3
+  category: tools
+  optional: true
+- name: docutils
+  version: 0.18.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.13,<3.14.0a0'
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.18.1-py313h78bf25f_1.conda
+  hash:
+    md5: 0d72df6ebc7870ee7f7486dde11b7732
+    sha256: 101d73deed8d839335d75ff2cdcb548ba666b699e16fd11488644efb0644cf7f
+  category: container
+  optional: true
+- name: docutils
+  version: 0.18.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.13,<3.14.0a0'
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.18.1-py313h78bf25f_1.conda
+  hash:
+    md5: 0d72df6ebc7870ee7f7486dde11b7732
+    sha256: 101d73deed8d839335d75ff2cdcb548ba666b699e16fd11488644efb0644cf7f
+  category: tools
+  optional: true
+- name: docutils
+  version: 0.18.1
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    python: '>=3.13,<3.14.0a0'
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/docutils-0.18.1-py313h1258fbd_1.conda
+  hash:
+    md5: dd3883c0dc8060914afc54adc91ae3b8
+    sha256: 97f06df81b07bb18aaaa12796c3050cbbe636aeff3bbb232df9e468691fb03d7
+  category: container
+  optional: true
+- name: docutils
+  version: 0.18.1
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    python: '>=3.13,<3.14.0a0'
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/docutils-0.18.1-py313h1258fbd_1.conda
+  hash:
+    md5: dd3883c0dc8060914afc54adc91ae3b8
+    sha256: 97f06df81b07bb18aaaa12796c3050cbbe636aeff3bbb232df9e468691fb03d7
+  category: tools
+  optional: true
+- name: docutils
+  version: 0.18.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.13,<3.14.0a0'
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/docutils-0.18.1-py313habf4b1d_1.conda
+  hash:
+    md5: 519530be33ce8adb6bec3a73689c702e
+    sha256: eae9678dafa79b95694fe13ad1049bb931b1c358675d64352193f1d3e31c0693
+  category: container
+  optional: true
+- name: docutils
+  version: 0.18.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.13,<3.14.0a0'
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/docutils-0.18.1-py313habf4b1d_1.conda
+  hash:
+    md5: 519530be33ce8adb6bec3a73689c702e
+    sha256: eae9678dafa79b95694fe13ad1049bb931b1c358675d64352193f1d3e31c0693
+  category: tools
+  optional: true
+- name: docutils
+  version: 0.18.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.13,<3.14.0a0'
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/docutils-0.18.1-py313h8f79df9_1.conda
+  hash:
+    md5: 3872bbedbb08bc79ad5b78792debb698
+    sha256: 18c04895a1f7663cb7f39e6f4cd696d8932ead398ef0c514ccfeaf7372269912
+  category: container
+  optional: true
+- name: docutils
+  version: 0.18.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.13,<3.14.0a0'
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/docutils-0.18.1-py313h8f79df9_1.conda
+  hash:
+    md5: 3872bbedbb08bc79ad5b78792debb698
+    sha256: 18c04895a1f7663cb7f39e6f4cd696d8932ead398ef0c514ccfeaf7372269912
+  category: tools
   optional: true
 - name: dulwich
   version: 0.24.10
@@ -9279,7 +7423,7 @@ package:
     conda-package-streaming: ''
     filelock: ''
     packaging: ''
-    python: ''
+    python: '>=3.10'
     requests: '>=2'
   url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.6.0-pyhcf101f3_0.conda
   hash:
@@ -9297,7 +7441,7 @@ package:
     conda-package-streaming: ''
     filelock: ''
     packaging: ''
-    python: ''
+    python: '>=3.10'
     requests: '>=2'
   url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.6.0-pyhcf101f3_0.conda
   hash:
@@ -9315,7 +7459,7 @@ package:
     conda-package-streaming: ''
     filelock: ''
     packaging: ''
-    python: ''
+    python: '>=3.10'
     requests: '>=2'
   url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.6.0-pyhcf101f3_0.conda
   hash:
@@ -10178,112 +8322,6 @@ package:
     sha256: 1ac5f5a3a35f2e4778025043c87993208d336e30539406e380e0952bb7ffd188
   category: notebooks
   optional: true
-- name: gflags
-  version: 2.2.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
-  hash:
-    md5: d411fc29e338efb48c5fd4576d71d881
-    sha256: 6c33bf0c4d8f418546ba9c250db4e4221040936aef8956353bc764d4877bc39a
-  category: container
-  optional: true
-- name: gflags
-  version: 2.2.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
-  hash:
-    md5: d411fc29e338efb48c5fd4576d71d881
-    sha256: 6c33bf0c4d8f418546ba9c250db4e4221040936aef8956353bc764d4877bc39a
-  category: notebooks
-  optional: true
-- name: gflags
-  version: 2.2.2
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gflags-2.2.2-h5ad3122_1005.conda
-  hash:
-    md5: 4ff634d515abbf664774b5e1168a9744
-    sha256: 28fe6b40b20454106d5e4ef6947cf298c13cc72a46347bbc49b563cd3a463bfa
-  category: container
-  optional: true
-- name: gflags
-  version: 2.2.2
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gflags-2.2.2-h5ad3122_1005.conda
-  hash:
-    md5: 4ff634d515abbf664774b5e1168a9744
-    sha256: 28fe6b40b20454106d5e4ef6947cf298c13cc72a46347bbc49b563cd3a463bfa
-  category: notebooks
-  optional: true
-- name: gflags
-  version: 2.2.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=17'
-  url: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
-  hash:
-    md5: a26de8814083a6971f14f9c8c3cb36c2
-    sha256: c0bea66f71a6f4baa8d4f0248e17f65033d558d9e882c0af571b38bcca3e4b46
-  category: container
-  optional: true
-- name: gflags
-  version: 2.2.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=17'
-  url: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
-  hash:
-    md5: a26de8814083a6971f14f9c8c3cb36c2
-    sha256: c0bea66f71a6f4baa8d4f0248e17f65033d558d9e882c0af571b38bcca3e4b46
-  category: notebooks
-  optional: true
-- name: gflags
-  version: 2.2.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=17'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
-  hash:
-    md5: 57a511a5905caa37540eb914dfcbf1fb
-    sha256: fd56ed8a1dab72ab90d8a8929b6f916a6d9220ca297ff077f8f04c5ed3408e20
-  category: container
-  optional: true
-- name: gflags
-  version: 2.2.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=17'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
-  hash:
-    md5: 57a511a5905caa37540eb914dfcbf1fb
-    sha256: fd56ed8a1dab72ab90d8a8929b6f916a6d9220ca297ff077f8f04c5ed3408e20
-  category: notebooks
-  optional: true
 - name: giflib
   version: 5.2.2
   manager: conda
@@ -10545,118 +8583,6 @@ package:
     md5: 98958318a01373a615f119b1040b3027
     sha256: 718c9d0cc287ffda978996c4105ddd2863dd7bad7fb5794cdd365bd809ef2fa5
   category: tools
-  optional: true
-- name: glog
-  version: 0.7.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    gflags: '>=2.2.2,<2.3.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
-  hash:
-    md5: ff862eebdfeb2fd048ae9dc92510baca
-    sha256: dc824dc1d0aa358e28da2ecbbb9f03d932d976c8dca11214aa1dcdfcbd054ba2
-  category: container
-  optional: true
-- name: glog
-  version: 0.7.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    gflags: '>=2.2.2,<2.3.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
-  hash:
-    md5: ff862eebdfeb2fd048ae9dc92510baca
-    sha256: dc824dc1d0aa358e28da2ecbbb9f03d932d976c8dca11214aa1dcdfcbd054ba2
-  category: notebooks
-  optional: true
-- name: glog
-  version: 0.7.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    gflags: '>=2.2.2,<2.3.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glog-0.7.1-h468a4a4_0.conda
-  hash:
-    md5: 08940a32c6ced3703d1412dd37df4f62
-    sha256: 920795d4f775a9f47e91c2223e64847f0b212b3fedc56c137c5889e32efe8ba0
-  category: container
-  optional: true
-- name: glog
-  version: 0.7.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    gflags: '>=2.2.2,<2.3.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glog-0.7.1-h468a4a4_0.conda
-  hash:
-    md5: 08940a32c6ced3703d1412dd37df4f62
-    sha256: 920795d4f775a9f47e91c2223e64847f0b212b3fedc56c137c5889e32efe8ba0
-  category: notebooks
-  optional: true
-- name: glog
-  version: 0.7.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    gflags: '>=2.2.2,<2.3.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
-  hash:
-    md5: 06cf91665775b0da395229cd4331b27d
-    sha256: dd56547db8625eb5c91bb0a9fbe8bd6f5c7fbf5b6059d46365e94472c46b24f9
-  category: container
-  optional: true
-- name: glog
-  version: 0.7.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    gflags: '>=2.2.2,<2.3.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
-  hash:
-    md5: 06cf91665775b0da395229cd4331b27d
-    sha256: dd56547db8625eb5c91bb0a9fbe8bd6f5c7fbf5b6059d46365e94472c46b24f9
-  category: notebooks
-  optional: true
-- name: glog
-  version: 0.7.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    gflags: '>=2.2.2,<2.3.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
-  hash:
-    md5: fef68d0a95aa5b84b5c1a4f6f3bf40e1
-    sha256: 9fc77de416953aa959039db72bc41bfa4600ae3ff84acad04a7d0c1ab9552602
-  category: container
-  optional: true
-- name: glog
-  version: 0.7.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    gflags: '>=2.2.2,<2.3.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
-  hash:
-    md5: fef68d0a95aa5b84b5c1a4f6f3bf40e1
-    sha256: 9fc77de416953aa959039db72bc41bfa4600ae3ff84acad04a7d0c1ab9552602
-  category: notebooks
   optional: true
 - name: gmp
   version: 6.3.0
@@ -10932,7 +8858,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
   hash:
@@ -10945,7 +8871,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
   hash:
@@ -10958,7 +8884,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
   hash:
@@ -10971,7 +8897,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
   hash:
@@ -10984,7 +8910,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
   hash:
@@ -10997,7 +8923,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
   hash:
@@ -11068,7 +8994,7 @@ package:
   dependencies:
     hpack: '>=4.1,<5'
     hyperframe: '>=6.1,<7'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   hash:
     md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -11082,7 +9008,7 @@ package:
   dependencies:
     hpack: '>=4.1,<5'
     hyperframe: '>=6.1,<7'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   hash:
     md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -11096,7 +9022,7 @@ package:
   dependencies:
     hpack: '>=4.1,<5'
     hyperframe: '>=6.1,<7'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   hash:
     md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -11110,7 +9036,7 @@ package:
   dependencies:
     hpack: '>=4.1,<5'
     hyperframe: '>=6.1,<7'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   hash:
     md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -11124,7 +9050,7 @@ package:
   dependencies:
     hpack: '>=4.1,<5'
     hyperframe: '>=6.1,<7'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   hash:
     md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -11138,7 +9064,7 @@ package:
   dependencies:
     hpack: '>=4.1,<5'
     hyperframe: '>=6.1,<7'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   hash:
     md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -11152,7 +9078,7 @@ package:
   dependencies:
     hpack: '>=4.1,<5'
     hyperframe: '>=6.1,<7'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   hash:
     md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -11166,7 +9092,7 @@ package:
   dependencies:
     hpack: '>=4.1,<5'
     hyperframe: '>=6.1,<7'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   hash:
     md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -11180,7 +9106,7 @@ package:
   dependencies:
     hpack: '>=4.1,<5'
     hyperframe: '>=6.1,<7'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   hash:
     md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -11194,7 +9120,7 @@ package:
   dependencies:
     hpack: '>=4.1,<5'
     hyperframe: '>=6.1,<7'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   hash:
     md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -11208,7 +9134,7 @@ package:
   dependencies:
     hpack: '>=4.1,<5'
     hyperframe: '>=6.1,<7'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   hash:
     md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -11222,7 +9148,7 @@ package:
   dependencies:
     hpack: '>=4.1,<5'
     hyperframe: '>=6.1,<7'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   hash:
     md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -11288,11 +9214,17 @@ package:
   category: notebooks
   optional: true
 - name: hdf5
-  version: 1.14.6
+  version: 2.1.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
+    aws-c-auth: '>=0.10.1,<0.10.2.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+    aws-c-s3: '>=0.12.2,<0.12.3.0a0'
+    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.20.0,<9.0a0'
     libgcc: '>=14'
@@ -11301,10 +9233,10 @@ package:
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
     openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_110.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h87a9417_105.conda
   hash:
-    md5: 9c6e11a83468e1d5decae516077a73fb
-    sha256: ac57ce3abbda2a82d6192bc36fbd7fe96e867d84c999ef81a3da034dfd01a995
+    md5: 0d0595612fa229dddb5fc565c260a11f
+    sha256: beb8a2fb18924ca7b5b82cfb50f008f882f577daef2c00ed88022abea35fec76
   category: notebooks
   optional: true
 - name: hdf5
@@ -11312,12 +9244,12 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    aws-c-auth: '>=0.10.1,<0.10.2.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
+    aws-c-s3: '>=0.12.2,<0.12.3.0a0'
+    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.20.0,<9.0a0'
     libgcc: '>=14'
@@ -11325,19 +9257,25 @@ package:
     libgfortran5: '>=14.3.0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h0973965_108.conda
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h6ea7a3c_105.conda
   hash:
-    md5: fda606c9f7d6418d748f1776b5d9d88a
-    sha256: 24899626cc632fd98e6ce1e00257f8f500ca60d18fc2a142da760a26b9c11eef
+    md5: 076103ea89b838e3e20b96985be64e88
+    sha256: 3f58ef9b51335d6f4a57d851de1c017eda4c12f3857b3f7722aeba6a6d30f9c8
   category: notebooks
   optional: true
 - name: hdf5
-  version: 1.14.6
+  version: 2.1.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
+    aws-c-auth: '>=0.10.1,<0.10.2.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
+    aws-c-io: '>=0.26.3,<0.26.4.0a0'
+    aws-c-s3: '>=0.12.2,<0.12.3.0a0'
+    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.20.0,<9.0a0'
     libcxx: '>=19'
@@ -11345,10 +9283,10 @@ package:
     libgfortran5: '>=14.3.0'
     libzlib: '>=1.3.2,<2.0a0'
     openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.6-nompi_h13accda_110.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-2.1.0-nompi_h650120f_105.conda
   hash:
-    md5: 8fa7c7e9a3c1b57a37bc03f0183aaf17
-    sha256: 76fdcb1295eedd01a697d55e871415dd606adc7661b6acd893d073e95240961e
+    md5: 215fed8f2ea2f3578416dfadcd25b4a1
+    sha256: 2dd1bf089ed2cd70bd461569ffa53023a8dcdbdf98547f65fe257c93aa1aa9d9
   category: notebooks
   optional: true
 - name: hdf5
@@ -11357,215 +9295,215 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-auth: '>=0.10.3,<0.10.4.0a0'
-    aws-c-common: '>=0.14.0,<0.14.1.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
+    aws-c-auth: '>=0.10.1,<0.10.2.0a0'
+    aws-c-common: '>=0.12.6,<0.12.7.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
-    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
+    aws-c-s3: '>=0.12.2,<0.12.3.0a0'
+    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.20.0,<9.0a0'
     libcxx: '>=19'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hb7e0c14_108.conda
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_he586413_105.conda
   hash:
-    md5: 5cc8ba7775f6694349b7a71837bbad90
-    sha256: 8f37c0185801b81a50e4e1430501ddd1c9bfe5e6a5e4ea3c61464e0f1d9199aa
+    md5: deb297adb6083474bb8b75b92172fb95
+    sha256: 518237c7e1e1f1f2d98f0283a483571b2d62c5c71b455a0ad0f0cc40087bb939
   category: notebooks
   optional: true
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: container
   optional: true
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: jupyter
   optional: true
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: notebooks
   optional: true
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: tools
   optional: true
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: container
   optional: true
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: jupyter
   optional: true
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: notebooks
   optional: true
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: tools
   optional: true
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: container
   optional: true
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: jupyter
   optional: true
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: notebooks
   optional: true
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: tools
   optional: true
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: container
   optional: true
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: jupyter
   optional: true
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: notebooks
   optional: true
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: tools
   optional: true
 - name: httpcore
@@ -11611,7 +9549,7 @@ package:
     certifi: ''
     h11: '>=0.16'
     h2: '>=3,<5'
-    python: ''
+    python: '>=3.9'
     sniffio: 1.*
   url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
   hash:
@@ -11628,7 +9566,7 @@ package:
     certifi: ''
     h11: '>=0.16'
     h2: '>=3,<5'
-    python: ''
+    python: '>=3.9'
     sniffio: 1.*
   url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
   hash:
@@ -11645,7 +9583,7 @@ package:
     certifi: ''
     h11: '>=0.16'
     h2: '>=3,<5'
-    python: ''
+    python: '>=3.9'
     sniffio: 1.*
   url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
   hash:
@@ -11662,7 +9600,7 @@ package:
     certifi: ''
     h11: '>=0.16'
     h2: '>=3,<5'
-    python: ''
+    python: '>=3.9'
     sniffio: 1.*
   url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
   hash:
@@ -11679,7 +9617,7 @@ package:
     certifi: ''
     h11: '>=0.16'
     h2: '>=3,<5'
-    python: ''
+    python: '>=3.9'
     sniffio: 1.*
   url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
   hash:
@@ -11696,7 +9634,7 @@ package:
     certifi: ''
     h11: '>=0.16'
     h2: '>=3,<5'
-    python: ''
+    python: '>=3.9'
     sniffio: 1.*
   url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
   hash:
@@ -12049,21 +9987,8 @@ package:
   hash:
     md5: 546da38c2fa9efacf203e2ad3f987c59
     sha256: 49ba6aed2c6b482bb0ba41078057555d29764299bc947b990708617712ef6406
-  category: container
-  optional: true
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
-  hash:
-    md5: 546da38c2fa9efacf203e2ad3f987c59
-    sha256: 49ba6aed2c6b482bb0ba41078057555d29764299bc947b990708617712ef6406
-  category: notebooks
-  optional: true
+  category: main
+  optional: false
 - name: icu
   version: '78.3'
   manager: conda
@@ -12098,20 +10023,8 @@ package:
   hash:
     md5: f1182c91c0de31a7abd40cedf6a5ebef
     sha256: 3a7907a17e9937d3a46dfd41cffaf815abad59a569440d1e25177c15fd0684e5
-  category: container
-  optional: true
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-  hash:
-    md5: f1182c91c0de31a7abd40cedf6a5ebef
-    sha256: 3a7907a17e9937d3a46dfd41cffaf815abad59a569440d1e25177c15fd0684e5
-  category: notebooks
-  optional: true
+  category: main
+  optional: false
 - name: idna
   version: '3.18'
   manager: conda
@@ -12165,7 +10078,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
     md5: 577b04680ae422adb86fc60d7b940659
@@ -12177,7 +10090,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
     md5: 577b04680ae422adb86fc60d7b940659
@@ -12189,7 +10102,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
     md5: 577b04680ae422adb86fc60d7b940659
@@ -12201,7 +10114,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
     md5: 577b04680ae422adb86fc60d7b940659
@@ -12213,7 +10126,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
     md5: 577b04680ae422adb86fc60d7b940659
@@ -12225,7 +10138,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
     md5: 577b04680ae422adb86fc60d7b940659
@@ -12237,7 +10150,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
     md5: 577b04680ae422adb86fc60d7b940659
@@ -12249,7 +10162,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
     md5: 577b04680ae422adb86fc60d7b940659
@@ -12261,7 +10174,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
     md5: 577b04680ae422adb86fc60d7b940659
@@ -12273,7 +10186,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
     md5: 577b04680ae422adb86fc60d7b940659
@@ -12285,7 +10198,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
     md5: 577b04680ae422adb86fc60d7b940659
@@ -12297,7 +10210,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
   hash:
     md5: 577b04680ae422adb86fc60d7b940659
@@ -12341,19 +10254,6 @@ package:
   hash:
     md5: ffc17e785d64e12fc311af9184221839
     sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
-  category: notebooks
-  optional: true
-- name: importlib-metadata
-  version: 9.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-    zipp: '>=3.20'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
-  hash:
-    md5: ffc17e785d64e12fc311af9184221839
-    sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
   category: tools
   optional: true
 - name: importlib-metadata
@@ -12361,7 +10261,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     zipp: '>=3.20'
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
   hash:
@@ -12374,7 +10274,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     zipp: '>=3.20'
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
   hash:
@@ -12387,20 +10287,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
-    zipp: '>=3.20'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
-  hash:
-    md5: ffc17e785d64e12fc311af9184221839
-    sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
-  category: notebooks
-  optional: true
-- name: importlib-metadata
-  version: 9.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: ''
+    python: '>=3.10'
     zipp: '>=3.20'
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
   hash:
@@ -12413,7 +10300,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     zipp: '>=3.20'
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
   hash:
@@ -12426,7 +10313,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     zipp: '>=3.20'
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
   hash:
@@ -12439,20 +10326,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
-    zipp: '>=3.20'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
-  hash:
-    md5: ffc17e785d64e12fc311af9184221839
-    sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
-  category: notebooks
-  optional: true
-- name: importlib-metadata
-  version: 9.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: ''
+    python: '>=3.10'
     zipp: '>=3.20'
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
   hash:
@@ -12465,7 +10339,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     zipp: '>=3.20'
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
   hash:
@@ -12478,7 +10352,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     zipp: '>=3.20'
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
   hash:
@@ -12491,20 +10365,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
-    zipp: '>=3.20'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
-  hash:
-    md5: ffc17e785d64e12fc311af9184221839
-    sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
-  category: notebooks
-  optional: true
-- name: importlib-metadata
-  version: 9.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
+    python: '>=3.10'
     zipp: '>=3.20'
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
   hash:
@@ -12758,7 +10619,7 @@ package:
     nest-asyncio2: '>=1.7.0'
     packaging: '>=22'
     psutil: '>=5.7'
-    python: ''
+    python: '>=3.10'
     pyzmq: '>=25'
     tornado: '>=6.4.1'
     traitlets: '>=5.4.0'
@@ -12783,7 +10644,7 @@ package:
     nest-asyncio2: '>=1.7.0'
     packaging: '>=22'
     psutil: '>=5.7'
-    python: ''
+    python: '>=3.10'
     pyzmq: '>=25'
     tornado: '>=6.4.1'
     traitlets: '>=5.4.0'
@@ -12808,7 +10669,7 @@ package:
     nest-asyncio2: '>=1.7.0'
     packaging: '>=22'
     psutil: '>=5.7'
-    python: ''
+    python: '>=3.10'
     pyzmq: '>=25'
     tornado: '>=6.4.1'
     traitlets: '>=5.4.0'
@@ -12834,7 +10695,7 @@ package:
     nest-asyncio2: '>=1.7.0'
     packaging: '>=22'
     psutil: '>=5.7'
-    python: ''
+    python: '>=3.10'
     pyzmq: '>=25'
     tornado: '>=6.4.1'
     traitlets: '>=5.4.0'
@@ -12860,7 +10721,7 @@ package:
     nest-asyncio2: '>=1.7.0'
     packaging: '>=22'
     psutil: '>=5.7'
-    python: ''
+    python: '>=3.10'
     pyzmq: '>=25'
     tornado: '>=6.4.1'
     traitlets: '>=5.4.0'
@@ -12886,7 +10747,7 @@ package:
     nest-asyncio2: '>=1.7.0'
     packaging: '>=22'
     psutil: '>=5.7'
-    python: ''
+    python: '>=3.10'
     pyzmq: '>=25'
     tornado: '>=6.4.1'
     traitlets: '>=5.4.0'
@@ -12912,7 +10773,7 @@ package:
     nest-asyncio2: '>=1.7.0'
     packaging: '>=22'
     psutil: '>=5.7'
-    python: ''
+    python: '>=3.10'
     pyzmq: '>=25'
     tornado: '>=6.4.1'
     traitlets: '>=5.4.0'
@@ -12938,7 +10799,7 @@ package:
     nest-asyncio2: '>=1.7.0'
     packaging: '>=22'
     psutil: '>=5.7'
-    python: ''
+    python: '>=3.10'
     pyzmq: '>=25'
     tornado: '>=6.4.1'
     traitlets: '>=5.4.0'
@@ -12964,7 +10825,7 @@ package:
     nest-asyncio2: '>=1.7.0'
     packaging: '>=22'
     psutil: '>=5.7'
-    python: ''
+    python: '>=3.10'
     pyzmq: '>=25'
     tornado: '>=6.4.1'
     traitlets: '>=5.4.0'
@@ -12975,7 +10836,7 @@ package:
   category: tools
   optional: true
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -12992,14 +10853,14 @@ package:
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: container
   optional: true
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -13016,14 +10877,14 @@ package:
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: jupyter
   optional: true
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -13040,14 +10901,14 @@ package:
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: notebooks
   optional: true
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -13064,14 +10925,14 @@ package:
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: tools
   optional: true
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -13084,18 +10945,18 @@ package:
     prompt-toolkit: '>=3.0.41,<3.1.0'
     psutil: '>=7'
     pygments: '>=2.14.0'
-    python: ''
+    python: '>=3.11'
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: container
   optional: true
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -13108,18 +10969,18 @@ package:
     prompt-toolkit: '>=3.0.41,<3.1.0'
     psutil: '>=7'
     pygments: '>=2.14.0'
-    python: ''
+    python: '>=3.11'
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: jupyter
   optional: true
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -13132,18 +10993,18 @@ package:
     prompt-toolkit: '>=3.0.41,<3.1.0'
     psutil: '>=7'
     pygments: '>=2.14.0'
-    python: ''
+    python: '>=3.11'
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: notebooks
   optional: true
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -13156,18 +11017,18 @@ package:
     prompt-toolkit: '>=3.0.41,<3.1.0'
     psutil: '>=7'
     pygments: '>=2.14.0'
-    python: ''
+    python: '>=3.11'
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: tools
   optional: true
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -13180,18 +11041,18 @@ package:
     prompt-toolkit: '>=3.0.41,<3.1.0'
     psutil: '>=7'
     pygments: '>=2.14.0'
-    python: ''
+    python: '>=3.11'
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: container
   optional: true
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -13204,18 +11065,18 @@ package:
     prompt-toolkit: '>=3.0.41,<3.1.0'
     psutil: '>=7'
     pygments: '>=2.14.0'
-    python: ''
+    python: '>=3.11'
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: jupyter
   optional: true
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -13228,18 +11089,18 @@ package:
     prompt-toolkit: '>=3.0.41,<3.1.0'
     psutil: '>=7'
     pygments: '>=2.14.0'
-    python: ''
+    python: '>=3.11'
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: notebooks
   optional: true
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -13252,18 +11113,18 @@ package:
     prompt-toolkit: '>=3.0.41,<3.1.0'
     psutil: '>=7'
     pygments: '>=2.14.0'
-    python: ''
+    python: '>=3.11'
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: tools
   optional: true
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -13276,18 +11137,18 @@ package:
     prompt-toolkit: '>=3.0.41,<3.1.0'
     psutil: '>=7'
     pygments: '>=2.14.0'
-    python: ''
+    python: '>=3.11'
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: container
   optional: true
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -13300,18 +11161,18 @@ package:
     prompt-toolkit: '>=3.0.41,<3.1.0'
     psutil: '>=7'
     pygments: '>=2.14.0'
-    python: ''
+    python: '>=3.11'
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: jupyter
   optional: true
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -13324,18 +11185,18 @@ package:
     prompt-toolkit: '>=3.0.41,<3.1.0'
     psutil: '>=7'
     pygments: '>=2.14.0'
-    python: ''
+    python: '>=3.11'
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: notebooks
   optional: true
 - name: ipython
-  version: 9.14.1
+  version: 9.15.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -13348,14 +11209,14 @@ package:
     prompt-toolkit: '>=3.0.41,<3.1.0'
     psutil: '>=7'
     pygments: '>=2.14.0'
-    python: ''
+    python: '>=3.11'
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.15.0-pyh53cf698_0.conda
   hash:
-    md5: fbd58549b374103c1a80577f09a328ef
-    sha256: a3f76e06c31bcf1bda0f633d5c9f1c834286b4f6decc6626067a6cffee283318
+    md5: 2f4ea7f616b30363d8dde5cc15e7af2e
+    sha256: d9fa14ec35119901bf702a9a3e8a5570daef2aada7d03878e4c24d9de912302b
   category: tools
   optional: true
 - name: ipython_pygments_lexers
@@ -13825,7 +11686,7 @@ package:
   platform: linux-aarch64
   dependencies:
     more-itertools: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhcf101f3_3.conda
   hash:
     md5: d59568bad316413c89831456e691de29
@@ -13838,7 +11699,7 @@ package:
   platform: osx-64
   dependencies:
     more-itertools: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhcf101f3_3.conda
   hash:
     md5: d59568bad316413c89831456e691de29
@@ -13851,7 +11712,7 @@ package:
   platform: osx-arm64
   dependencies:
     more-itertools: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhcf101f3_3.conda
   hash:
     md5: d59568bad316413c89831456e691de29
@@ -13877,7 +11738,7 @@ package:
   platform: linux-aarch64
   dependencies:
     backports.tarfile: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
   hash:
     md5: b9d2b1ffa307961f6bb7d83c8ba8a8be
@@ -13890,7 +11751,7 @@ package:
   platform: osx-64
   dependencies:
     backports.tarfile: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
   hash:
     md5: b9d2b1ffa307961f6bb7d83c8ba8a8be
@@ -13903,7 +11764,7 @@ package:
   platform: osx-arm64
   dependencies:
     backports.tarfile: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
   hash:
     md5: b9d2b1ffa307961f6bb7d83c8ba8a8be
@@ -13929,7 +11790,7 @@ package:
   platform: linux-aarch64
   dependencies:
     more-itertools: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
   hash:
     md5: 8e33f6f90e5de5efd971840c7634d954
@@ -13942,7 +11803,7 @@ package:
   platform: osx-64
   dependencies:
     more-itertools: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
   hash:
     md5: 8e33f6f90e5de5efd971840c7634d954
@@ -13955,7 +11816,7 @@ package:
   platform: osx-arm64
   dependencies:
     more-itertools: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
   hash:
     md5: 8e33f6f90e5de5efd971840c7634d954
@@ -13963,211 +11824,211 @@ package:
   category: tools
   optional: true
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: linux-64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: container
   optional: true
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: linux-64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: jupyter
   optional: true
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: linux-64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: notebooks
   optional: true
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: linux-64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: tools
   optional: true
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: linux-aarch64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: container
   optional: true
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: linux-aarch64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: jupyter
   optional: true
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: linux-aarch64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: notebooks
   optional: true
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: linux-aarch64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: tools
   optional: true
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: osx-64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: container
   optional: true
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: osx-64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: jupyter
   optional: true
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: osx-64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: notebooks
   optional: true
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: osx-64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: tools
   optional: true
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: container
   optional: true
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: jupyter
   optional: true
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: notebooks
   optional: true
 - name: jedi
-  version: 0.19.2
+  version: 0.20.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+    parso: '>=0.8.6,<0.9.0'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
   hash:
-    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
-    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+    md5: c2b3d37aa1411031126036ee76a8a861
+    sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
   category: tools
   optional: true
 - name: jeepney
@@ -14252,7 +12113,7 @@ package:
   platform: linux-aarch64
   dependencies:
     markupsafe: '>=2.0'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
   hash:
     md5: 04558c96691bed63104678757beb4f8d
@@ -14265,7 +12126,7 @@ package:
   platform: linux-aarch64
   dependencies:
     markupsafe: '>=2.0'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
   hash:
     md5: 04558c96691bed63104678757beb4f8d
@@ -14278,7 +12139,7 @@ package:
   platform: linux-aarch64
   dependencies:
     markupsafe: '>=2.0'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
   hash:
     md5: 04558c96691bed63104678757beb4f8d
@@ -14291,7 +12152,7 @@ package:
   platform: linux-aarch64
   dependencies:
     markupsafe: '>=2.0'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
   hash:
     md5: 04558c96691bed63104678757beb4f8d
@@ -14304,7 +12165,7 @@ package:
   platform: osx-64
   dependencies:
     markupsafe: '>=2.0'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
   hash:
     md5: 04558c96691bed63104678757beb4f8d
@@ -14317,7 +12178,7 @@ package:
   platform: osx-64
   dependencies:
     markupsafe: '>=2.0'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
   hash:
     md5: 04558c96691bed63104678757beb4f8d
@@ -14330,7 +12191,7 @@ package:
   platform: osx-64
   dependencies:
     markupsafe: '>=2.0'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
   hash:
     md5: 04558c96691bed63104678757beb4f8d
@@ -14343,7 +12204,7 @@ package:
   platform: osx-64
   dependencies:
     markupsafe: '>=2.0'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
   hash:
     md5: 04558c96691bed63104678757beb4f8d
@@ -14356,7 +12217,7 @@ package:
   platform: osx-arm64
   dependencies:
     markupsafe: '>=2.0'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
   hash:
     md5: 04558c96691bed63104678757beb4f8d
@@ -14369,7 +12230,7 @@ package:
   platform: osx-arm64
   dependencies:
     markupsafe: '>=2.0'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
   hash:
     md5: 04558c96691bed63104678757beb4f8d
@@ -14382,7 +12243,7 @@ package:
   platform: osx-arm64
   dependencies:
     markupsafe: '>=2.0'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
   hash:
     md5: 04558c96691bed63104678757beb4f8d
@@ -14395,11 +12256,155 @@ package:
   platform: osx-arm64
   dependencies:
     markupsafe: '>=2.0'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
   hash:
     md5: 04558c96691bed63104678757beb4f8d
     sha256: fc9ca7348a4f25fed2079f2153ecdcf5f9cf2a0bc36c4172420ca09e1849df7b
+  category: tools
+  optional: true
+- name: jmespath
+  version: 1.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 972bdca8f30147135f951847b30399ea
+    sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
+  category: container
+  optional: true
+- name: jmespath
+  version: 1.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 972bdca8f30147135f951847b30399ea
+    sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
+  category: notebooks
+  optional: true
+- name: jmespath
+  version: 1.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 972bdca8f30147135f951847b30399ea
+    sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
+  category: tools
+  optional: true
+- name: jmespath
+  version: 1.0.1
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 972bdca8f30147135f951847b30399ea
+    sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
+  category: container
+  optional: true
+- name: jmespath
+  version: 1.0.1
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 972bdca8f30147135f951847b30399ea
+    sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
+  category: notebooks
+  optional: true
+- name: jmespath
+  version: 1.0.1
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 972bdca8f30147135f951847b30399ea
+    sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
+  category: tools
+  optional: true
+- name: jmespath
+  version: 1.0.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 972bdca8f30147135f951847b30399ea
+    sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
+  category: container
+  optional: true
+- name: jmespath
+  version: 1.0.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 972bdca8f30147135f951847b30399ea
+    sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
+  category: notebooks
+  optional: true
+- name: jmespath
+  version: 1.0.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 972bdca8f30147135f951847b30399ea
+    sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
+  category: tools
+  optional: true
+- name: jmespath
+  version: 1.0.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 972bdca8f30147135f951847b30399ea
+    sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
+  category: container
+  optional: true
+- name: jmespath
+  version: 1.0.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 972bdca8f30147135f951847b30399ea
+    sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
+  category: notebooks
+  optional: true
+- name: jmespath
+  version: 1.0.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 972bdca8f30147135f951847b30399ea
+    sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
   category: tools
   optional: true
 - name: json-c
@@ -14576,7 +12581,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
   hash:
     md5: 89bf346df77603055d3c8fe5811691e6
@@ -14588,7 +12593,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
   hash:
     md5: 89bf346df77603055d3c8fe5811691e6
@@ -14600,7 +12605,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
   hash:
     md5: 89bf346df77603055d3c8fe5811691e6
@@ -14612,7 +12617,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
   hash:
     md5: 89bf346df77603055d3c8fe5811691e6
@@ -14624,7 +12629,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
   hash:
     md5: 89bf346df77603055d3c8fe5811691e6
@@ -14636,7 +12641,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
   hash:
     md5: 89bf346df77603055d3c8fe5811691e6
@@ -14698,7 +12703,7 @@ package:
   dependencies:
     attrs: '>=22.2.0'
     jsonschema-specifications: '>=2023.3.6'
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.28.4'
     rpds-py: '>=0.25.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
@@ -14714,7 +12719,7 @@ package:
   dependencies:
     attrs: '>=22.2.0'
     jsonschema-specifications: '>=2023.3.6'
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.28.4'
     rpds-py: '>=0.25.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
@@ -14730,7 +12735,7 @@ package:
   dependencies:
     attrs: '>=22.2.0'
     jsonschema-specifications: '>=2023.3.6'
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.28.4'
     rpds-py: '>=0.25.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
@@ -14746,7 +12751,7 @@ package:
   dependencies:
     attrs: '>=22.2.0'
     jsonschema-specifications: '>=2023.3.6'
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.28.4'
     rpds-py: '>=0.25.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
@@ -14762,7 +12767,7 @@ package:
   dependencies:
     attrs: '>=22.2.0'
     jsonschema-specifications: '>=2023.3.6'
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.28.4'
     rpds-py: '>=0.25.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
@@ -14778,7 +12783,7 @@ package:
   dependencies:
     attrs: '>=22.2.0'
     jsonschema-specifications: '>=2023.3.6'
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.28.4'
     rpds-py: '>=0.25.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
@@ -14794,7 +12799,7 @@ package:
   dependencies:
     attrs: '>=22.2.0'
     jsonschema-specifications: '>=2023.3.6'
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.28.4'
     rpds-py: '>=0.25.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
@@ -14810,7 +12815,7 @@ package:
   dependencies:
     attrs: '>=22.2.0'
     jsonschema-specifications: '>=2023.3.6'
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.28.4'
     rpds-py: '>=0.25.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
@@ -14826,7 +12831,7 @@ package:
   dependencies:
     attrs: '>=22.2.0'
     jsonschema-specifications: '>=2023.3.6'
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.28.4'
     rpds-py: '>=0.25.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
@@ -14879,7 +12884,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.31.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
   hash:
@@ -14892,7 +12897,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.31.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
   hash:
@@ -14905,7 +12910,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.31.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
   hash:
@@ -14918,7 +12923,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.31.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
   hash:
@@ -14931,7 +12936,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.31.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
   hash:
@@ -14944,7 +12949,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.31.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
   hash:
@@ -14957,7 +12962,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.31.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
   hash:
@@ -14970,7 +12975,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.31.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
   hash:
@@ -14983,7 +12988,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     referencing: '>=0.31.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
   hash:
@@ -15194,7 +13199,7 @@ package:
   dependencies:
     importlib-metadata: '>=4.8.3'
     jupyter_server: '>=1.1.2'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
   hash:
     md5: 0c3b465ceee138b9c39279cc02e5c4a0
@@ -15208,7 +13213,7 @@ package:
   dependencies:
     importlib-metadata: '>=4.8.3'
     jupyter_server: '>=1.1.2'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
   hash:
     md5: 0c3b465ceee138b9c39279cc02e5c4a0
@@ -15222,7 +13227,7 @@ package:
   dependencies:
     importlib-metadata: '>=4.8.3'
     jupyter_server: '>=1.1.2'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
   hash:
     md5: 0c3b465ceee138b9c39279cc02e5c4a0
@@ -15236,7 +13241,7 @@ package:
   dependencies:
     importlib-metadata: '>=4.8.3'
     jupyter_server: '>=1.1.2'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
   hash:
     md5: 0c3b465ceee138b9c39279cc02e5c4a0
@@ -15250,7 +13255,7 @@ package:
   dependencies:
     importlib-metadata: '>=4.8.3'
     jupyter_server: '>=1.1.2'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
   hash:
     md5: 0c3b465ceee138b9c39279cc02e5c4a0
@@ -15264,7 +13269,7 @@ package:
   dependencies:
     importlib-metadata: '>=4.8.3'
     jupyter_server: '>=1.1.2'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
   hash:
     md5: 0c3b465ceee138b9c39279cc02e5c4a0
@@ -15443,7 +13448,7 @@ package:
   platform: linux-aarch64
   dependencies:
     jupyter_core: '>=5.1'
-    python: ''
+    python: '>=3.10'
     python-dateutil: '>=2.8.2'
     pyzmq: '>=25.0'
     tornado: '>=6.4.1'
@@ -15461,7 +13466,7 @@ package:
   platform: linux-aarch64
   dependencies:
     jupyter_core: '>=5.1'
-    python: ''
+    python: '>=3.10'
     python-dateutil: '>=2.8.2'
     pyzmq: '>=25.0'
     tornado: '>=6.4.1'
@@ -15479,7 +13484,7 @@ package:
   platform: linux-aarch64
   dependencies:
     jupyter_core: '>=5.1'
-    python: ''
+    python: '>=3.10'
     python-dateutil: '>=2.8.2'
     pyzmq: '>=25.0'
     tornado: '>=6.4.1'
@@ -15497,7 +13502,7 @@ package:
   platform: osx-64
   dependencies:
     jupyter_core: '>=5.1'
-    python: ''
+    python: '>=3.10'
     python-dateutil: '>=2.8.2'
     pyzmq: '>=25.0'
     tornado: '>=6.4.1'
@@ -15515,7 +13520,7 @@ package:
   platform: osx-64
   dependencies:
     jupyter_core: '>=5.1'
-    python: ''
+    python: '>=3.10'
     python-dateutil: '>=2.8.2'
     pyzmq: '>=25.0'
     tornado: '>=6.4.1'
@@ -15533,7 +13538,7 @@ package:
   platform: osx-64
   dependencies:
     jupyter_core: '>=5.1'
-    python: ''
+    python: '>=3.10'
     python-dateutil: '>=2.8.2'
     pyzmq: '>=25.0'
     tornado: '>=6.4.1'
@@ -15551,7 +13556,7 @@ package:
   platform: osx-arm64
   dependencies:
     jupyter_core: '>=5.1'
-    python: ''
+    python: '>=3.10'
     python-dateutil: '>=2.8.2'
     pyzmq: '>=25.0'
     tornado: '>=6.4.1'
@@ -15569,7 +13574,7 @@ package:
   platform: osx-arm64
   dependencies:
     jupyter_core: '>=5.1'
-    python: ''
+    python: '>=3.10'
     python-dateutil: '>=2.8.2'
     pyzmq: '>=25.0'
     tornado: '>=6.4.1'
@@ -15587,7 +13592,7 @@ package:
   platform: osx-arm64
   dependencies:
     jupyter_core: '>=5.1'
-    python: ''
+    python: '>=3.10'
     python-dateutil: '>=2.8.2'
     pyzmq: '>=25.0'
     tornado: '>=6.4.1'
@@ -15826,7 +13831,7 @@ package:
   dependencies:
     jsonschema-with-format-nongpl: '>=4.18.0'
     packaging: ''
-    python: ''
+    python: '>=3.10'
     python-json-logger: '>=2.0.4'
     pyyaml: '>=5.3'
     referencing: ''
@@ -15846,7 +13851,7 @@ package:
   dependencies:
     jsonschema-with-format-nongpl: '>=4.18.0'
     packaging: ''
-    python: ''
+    python: '>=3.10'
     python-json-logger: '>=2.0.4'
     pyyaml: '>=5.3'
     referencing: ''
@@ -15866,7 +13871,7 @@ package:
   dependencies:
     jsonschema-with-format-nongpl: '>=4.18.0'
     packaging: ''
-    python: ''
+    python: '>=3.10'
     python-json-logger: '>=2.0.4'
     pyyaml: '>=5.3'
     referencing: ''
@@ -15886,7 +13891,7 @@ package:
   dependencies:
     jsonschema-with-format-nongpl: '>=4.18.0'
     packaging: ''
-    python: ''
+    python: '>=3.10'
     python-json-logger: '>=2.0.4'
     pyyaml: '>=5.3'
     referencing: ''
@@ -15906,7 +13911,7 @@ package:
   dependencies:
     jsonschema-with-format-nongpl: '>=4.18.0'
     packaging: ''
-    python: ''
+    python: '>=3.10'
     python-json-logger: '>=2.0.4'
     pyyaml: '>=5.3'
     referencing: ''
@@ -15926,7 +13931,7 @@ package:
   dependencies:
     jsonschema-with-format-nongpl: '>=4.18.0'
     packaging: ''
-    python: ''
+    python: '>=3.10'
     python-json-logger: '>=2.0.4'
     pyyaml: '>=5.3'
     referencing: ''
@@ -16016,7 +14021,7 @@ package:
     overrides: '>=5.0'
     packaging: '>=22.0'
     prometheus_client: '>=0.9'
-    python: ''
+    python: '>=3.10'
     pyzmq: '>=24'
     send2trash: '>=1.8.2'
     terminado: '>=0.8.3'
@@ -16046,7 +14051,7 @@ package:
     overrides: '>=5.0'
     packaging: '>=22.0'
     prometheus_client: '>=0.9'
-    python: ''
+    python: '>=3.10'
     pyzmq: '>=24'
     send2trash: '>=1.8.2'
     terminado: '>=0.8.3'
@@ -16076,7 +14081,7 @@ package:
     overrides: '>=5.0'
     packaging: '>=22.0'
     prometheus_client: '>=0.9'
-    python: ''
+    python: '>=3.10'
     pyzmq: '>=24'
     send2trash: '>=1.8.2'
     terminado: '>=0.8.3'
@@ -16106,7 +14111,7 @@ package:
     overrides: '>=5.0'
     packaging: '>=22.0'
     prometheus_client: '>=0.9'
-    python: ''
+    python: '>=3.10'
     pyzmq: '>=24'
     send2trash: '>=1.8.2'
     terminado: '>=0.8.3'
@@ -16136,7 +14141,7 @@ package:
     overrides: '>=5.0'
     packaging: '>=22.0'
     prometheus_client: '>=0.9'
-    python: ''
+    python: '>=3.10'
     pyzmq: '>=24'
     send2trash: '>=1.8.2'
     terminado: '>=0.8.3'
@@ -16166,7 +14171,7 @@ package:
     overrides: '>=5.0'
     packaging: '>=22.0'
     prometheus_client: '>=0.9'
-    python: ''
+    python: '>=3.10'
     pyzmq: '>=24'
     send2trash: '>=1.8.2'
     terminado: '>=0.8.3'
@@ -16210,7 +14215,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     terminado: '>=0.8.3'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
   hash:
@@ -16223,7 +14228,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     terminado: '>=0.8.3'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
   hash:
@@ -16236,7 +14241,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     terminado: '>=0.8.3'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
   hash:
@@ -16249,7 +14254,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     terminado: '>=0.8.3'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
   hash:
@@ -16262,7 +14267,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     terminado: '>=0.8.3'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
   hash:
@@ -16275,7 +14280,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     terminado: '>=0.8.3'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
   hash:
@@ -16327,7 +14332,7 @@ package:
     pamela: ''
     prometheus_client: '>=0.5.0'
     pydantic: '>=2'
-    python: ''
+    python: '>=3.10'
     python-dateutil: ''
     requests: ''
     sqlalchemy: '>=1.4.1'
@@ -16355,7 +14360,7 @@ package:
     pamela: ''
     prometheus_client: '>=0.5.0'
     pydantic: '>=2'
-    python: ''
+    python: '>=3.10'
     python-dateutil: ''
     requests: ''
     sqlalchemy: '>=1.4.1'
@@ -16383,7 +14388,7 @@ package:
     pamela: ''
     prometheus_client: '>=0.5.0'
     pydantic: '>=2'
-    python: ''
+    python: '>=3.10'
     python-dateutil: ''
     requests: ''
     sqlalchemy: '>=1.4.1'
@@ -16812,7 +14817,7 @@ package:
     jsonschema: '>=4.18'
     jupyter_server: '>=1.21,<3'
     packaging: '>=21.3'
-    python: ''
+    python: '>=3.10'
     requests: '>=2.31'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
   hash:
@@ -16831,7 +14836,7 @@ package:
     jsonschema: '>=4.18'
     jupyter_server: '>=1.21,<3'
     packaging: '>=21.3'
-    python: ''
+    python: '>=3.10'
     requests: '>=2.31'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
   hash:
@@ -16850,7 +14855,7 @@ package:
     jsonschema: '>=4.18'
     jupyter_server: '>=1.21,<3'
     packaging: '>=21.3'
-    python: ''
+    python: '>=3.10'
     requests: '>=2.31'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
   hash:
@@ -16869,7 +14874,7 @@ package:
     jsonschema: '>=4.18'
     jupyter_server: '>=1.21,<3'
     packaging: '>=21.3'
-    python: ''
+    python: '>=3.10'
     requests: '>=2.31'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
   hash:
@@ -16888,7 +14893,7 @@ package:
     jsonschema: '>=4.18'
     jupyter_server: '>=1.21,<3'
     packaging: '>=21.3'
-    python: ''
+    python: '>=3.10'
     requests: '>=2.31'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
   hash:
@@ -16907,7 +14912,7 @@ package:
     jsonschema: '>=4.18'
     jupyter_server: '>=1.21,<3'
     packaging: '>=21.3'
-    python: ''
+    python: '>=3.10'
     requests: '>=2.31'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
   hash:
@@ -16944,7 +14949,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.16-pyhcf101f3_1.conda
   hash:
     md5: dbf8b81974504fa51d34e436ca7ef389
@@ -16956,7 +14961,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.16-pyhcf101f3_1.conda
   hash:
     md5: dbf8b81974504fa51d34e436ca7ef389
@@ -16968,7 +14973,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.16-pyhcf101f3_1.conda
   hash:
     md5: dbf8b81974504fa51d34e436ca7ef389
@@ -16980,7 +14985,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.16-pyhcf101f3_1.conda
   hash:
     md5: dbf8b81974504fa51d34e436ca7ef389
@@ -16992,7 +14997,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.16-pyhcf101f3_1.conda
   hash:
     md5: dbf8b81974504fa51d34e436ca7ef389
@@ -17004,7 +15009,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.16-pyhcf101f3_1.conda
   hash:
     md5: dbf8b81974504fa51d34e436ca7ef389
@@ -17534,120 +15539,6 @@ package:
     md5: 9b965c999135d43a3d0f7bd7d024e26a
     sha256: 49570840fb15f5df5d4b4464db8ee43a6d643031a2bc70ef52120a52e3809699
   category: jupyter
-  optional: true
-- name: lcms2
-  version: 2.19.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
-  hash:
-    md5: 8b3ce45e929cd8e8e5f4d18586b56d8b
-    sha256: 112b5b9462572d970f4abd2912f76a25ee7db158b1e7260163d91dd8a630db84
-  category: container
-  optional: true
-- name: lcms2
-  version: 2.19.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
-  hash:
-    md5: 8b3ce45e929cd8e8e5f4d18586b56d8b
-    sha256: 112b5b9462572d970f4abd2912f76a25ee7db158b1e7260163d91dd8a630db84
-  category: notebooks
-  optional: true
-- name: lcms2
-  version: 2.19.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lcms2-2.19.1-h9d5b58d_1.conda
-  hash:
-    md5: 9183fda4be2b4ee5760cdb8e540439c8
-    sha256: ed213207bbf11663181941e0931caa9ce748f0544688e8e0fbcf330bca279389
-  category: container
-  optional: true
-- name: lcms2
-  version: 2.19.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lcms2-2.19.1-h9d5b58d_1.conda
-  hash:
-    md5: 9183fda4be2b4ee5760cdb8e540439c8
-    sha256: ed213207bbf11663181941e0931caa9ce748f0544688e8e0fbcf330bca279389
-  category: notebooks
-  optional: true
-- name: lcms2
-  version: 2.19.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.19.1-h5ea7634_1.conda
-  hash:
-    md5: f8c168eefc1f75ada2e2cd8f2e6212f5
-    sha256: 8bae1207dc7cf0e670ae920a549b1d55486514213ca808b8119067cbad0db43a
-  category: container
-  optional: true
-- name: lcms2
-  version: 2.19.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.19.1-h5ea7634_1.conda
-  hash:
-    md5: f8c168eefc1f75ada2e2cd8f2e6212f5
-    sha256: 8bae1207dc7cf0e670ae920a549b1d55486514213ca808b8119067cbad0db43a
-  category: notebooks
-  optional: true
-- name: lcms2
-  version: 2.19.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.19.1-hdfa7624_1.conda
-  hash:
-    md5: d2f2c7c10e2957647d45589b7701a453
-    sha256: ccb5598fad3694e79bf54f0eb812e3b3c3dd63d1497e631f5978800eadb9bcc4
-  category: container
-  optional: true
-- name: lcms2
-  version: 2.19.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.19.1-hdfa7624_1.conda
-  hash:
-    md5: d2f2c7c10e2957647d45589b7701a453
-    sha256: ccb5598fad3694e79bf54f0eb812e3b3c3dd63d1497e631f5978800eadb9bcc4
-  category: notebooks
   optional: true
 - name: ld_impl_linux-64
   version: 2.45.1
@@ -17686,34 +15577,7 @@ package:
   hash:
     md5: a752488c68f2e7c456bcbd8f16eec275
     sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
-  category: container
-  optional: true
-- name: lerc
-  version: 4.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
-  hash:
-    md5: a752488c68f2e7c456bcbd8f16eec275
-    sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
   category: notebooks
-  optional: true
-- name: lerc
-  version: 4.1.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
-  hash:
-    md5: d13423b06447113a90b5b1366d4da171
-    sha256: 8957fd460c1c132c8031f65fd5f56ec3807fd71b7cab2c5e2b0937b13404ab36
-  category: container
   optional: true
 - name: lerc
   version: 4.1.0
@@ -17739,19 +15603,6 @@ package:
   hash:
     md5: d2fe7e177d1c97c985140bd54e2a5e33
     sha256: f918716c71c8bebbc0c40e1050878aa512fea92c1d17c363ca35650bc60f6c35
-  category: container
-  optional: true
-- name: lerc
-  version: 4.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.1.0-h35c7297_0.conda
-  hash:
-    md5: d2fe7e177d1c97c985140bd54e2a5e33
-    sha256: f918716c71c8bebbc0c40e1050878aa512fea92c1d17c363ca35650bc60f6c35
   category: notebooks
   optional: true
 - name: lerc
@@ -17765,73 +15616,33 @@ package:
   hash:
     md5: 095e5749868adab9cae42d4b460e5443
     sha256: 66e5ffd301a44da696f3efc2f25d6d94f42a9adc0db06c44ad753ab844148c51
-  category: container
-  optional: true
-- name: lerc
-  version: 4.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.1.0-h1eee2c3_0.conda
-  hash:
-    md5: 095e5749868adab9cae42d4b460e5443
-    sha256: 66e5ffd301a44da696f3efc2f25d6d94f42a9adc0db06c44ad753ab844148c51
   category: notebooks
   optional: true
 - name: libabseil
-  version: '20260107.1'
+  version: '20260526.0'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260526.0-cxx17_h7b12aa8_1.conda
   hash:
-    md5: 6f7b4302263347698fd24565fbf11310
-    sha256: a7a4481a4d217a3eadea0ec489826a69070fcc3153f00443aa491ed21527d239
-  category: container
-  optional: true
-- name: libabseil
-  version: '20260107.1'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
-  hash:
-    md5: 6f7b4302263347698fd24565fbf11310
-    sha256: a7a4481a4d217a3eadea0ec489826a69070fcc3153f00443aa491ed21527d239
+    md5: c4393db381bffa0a83a8d9e47b238106
+    sha256: 32933de2d4fa6e6ffd949052815b49cb65a0649ad70007155c533ab97ea8cefd
   category: notebooks
   optional: true
 - name: libabseil
-  version: '20260107.1'
+  version: '20260526.0'
   manager: conda
   platform: linux-aarch64
   dependencies:
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20260107.1-cxx17_h6983b43_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20260526.0-cxx17_h6983b43_1.conda
   hash:
-    md5: 2a19160c13e688710dd200812fc9a6d3
-    sha256: 37675140819e10235a8ff342cb09f688f843ac390b64856d8e230700bbd7d5aa
-  category: container
-  optional: true
-- name: libabseil
-  version: '20260107.1'
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20260107.1-cxx17_h6983b43_0.conda
-  hash:
-    md5: 2a19160c13e688710dd200812fc9a6d3
-    sha256: 37675140819e10235a8ff342cb09f688f843ac390b64856d8e230700bbd7d5aa
+    md5: d8637f7cc7143fe4ad2eceac8e8cf033
+    sha256: 51f53ae6266889f0972a10c2773465da5554fdf55ac15b9dea3e7f77520022d9
   category: notebooks
   optional: true
 - name: libabseil
@@ -17845,33 +15656,7 @@ package:
   hash:
     md5: 317f40d7bd7bf6d54b56d4a5b5f5085d
     sha256: 2b4ff36082ddfbacc47ac6e11d4dd9f3403cd109ce8d7f0fbee0cdd47cdef013
-  category: container
-  optional: true
-- name: libabseil
-  version: '20260107.1'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20260107.1-cxx17_h7ed6875_0.conda
-  hash:
-    md5: 317f40d7bd7bf6d54b56d4a5b5f5085d
-    sha256: 2b4ff36082ddfbacc47ac6e11d4dd9f3403cd109ce8d7f0fbee0cdd47cdef013
   category: notebooks
-  optional: true
-- name: libabseil
-  version: '20260107.1'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
-  hash:
-    md5: bb65152e0d7c7178c0f1ee25692c9fd1
-    sha256: 756611fbb8d2957a5b4635d9772bd8432cb6ddac05580a6284cca6fdc9b07fca
-  category: container
   optional: true
 - name: libabseil
   version: '20260107.1'
@@ -17940,7 +15725,7 @@ package:
   category: notebooks
   optional: true
 - name: libarchive
-  version: 3.8.7
+  version: 3.8.8
   manager: conda
   platform: linux-64
   dependencies:
@@ -17953,16 +15738,16 @@ package:
     libzlib: '>=1.3.2,<2.0a0'
     lz4-c: '>=1.10.0,<1.11.0a0'
     lzo: '>=2.10,<3.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.7-gpl_hc2c16d8_101.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.8-gpl_hc2c16d8_100.conda
   hash:
-    md5: bb1483d91797dae0b466cab86ceb59a7
-    sha256: 78dd3d493d72c7d7c7647912fe383a3545a2695ee308037b64e9d0752ccedbe9
+    md5: 44652e646cb623f486ea72e7e7479222
+    sha256: f916b51f55f51a9bb2d902e0a5f029490f7b745aee549c349751c1787ddc26b8
   category: notebooks
   optional: true
 - name: libarchive
-  version: 3.8.7
+  version: 3.8.8
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -17974,16 +15759,16 @@ package:
     libzlib: '>=1.3.2,<2.0a0'
     lz4-c: '>=1.10.0,<1.11.0a0'
     lzo: '>=2.10,<3.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarchive-3.8.7-gpl_hbe7d12b_101.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarchive-3.8.8-gpl_hbe7d12b_100.conda
   hash:
-    md5: 5420789510bfaf085262fec8f15b7a64
-    sha256: 48382f97e0ab02d758cfaec81d7df6fd1ee665c4e917c02d36b7e1a15369396e
+    md5: a023664e901257bc10437c26a4923528
+    sha256: 74ee8968f3abdb7c1cec4b6701791b8bfcc6ba7b79de2aa76e2042a86fb3a6ec
   category: notebooks
   optional: true
 - name: libarchive
-  version: 3.8.7
+  version: 3.8.8
   manager: conda
   platform: osx-64
   dependencies:
@@ -17996,16 +15781,16 @@ package:
     libzlib: '>=1.3.2,<2.0a0'
     lz4-c: '>=1.10.0,<1.11.0a0'
     lzo: '>=2.10,<3.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.8.7-gpl_h2bf6321_101.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.8.8-gpl_h2bf6321_100.conda
   hash:
-    md5: c3fd696b58fdb6339e08140545f7839d
-    sha256: 8b4453a58e56d94a8829b9eebad004e3cdb0620f18587c5074fa16f130194d8d
+    md5: 221bc6aaa394cd9476607cb3d104c203
+    sha256: a232061dd89072b4abfa53236fa0f06ffde33841fd9fba31b08af641b8c675f9
   category: notebooks
   optional: true
 - name: libarchive
-  version: 3.8.7
+  version: 3.8.8
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -18018,858 +15803,12 @@ package:
     libzlib: '>=1.3.2,<2.0a0'
     lz4-c: '>=1.10.0,<1.11.0a0'
     lzo: '>=2.10,<3.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.8.7-gpl_h6fbacd7_101.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.8.8-gpl_h6fbacd7_100.conda
   hash:
-    md5: f88655b640e9ffc8f0c3f08122e0bb31
-    sha256: 6c9598cf7e9e7785a95fd21c7bd257ab3a788d17e973ba497e18b26551859b88
-  category: notebooks
-  optional: true
-- name: libarrow
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
-    aws-sdk-cpp: '>=1.11.747,<1.11.748.0a0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-identity-cpp: '>=1.13.3,<1.13.4.0a0'
-    azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
-    azure-storage-files-datalake-cpp: '>=12.16.0,<12.16.1.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    glog: '>=0.7.1,<0.8.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libgcc: '>=14'
-    libgoogle-cloud: '>=3.5.0,<3.6.0a0'
-    libgoogle-cloud-storage: '>=3.5.0,<3.6.0a0'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    orc: '>=2.3.0,<2.3.1.0a0'
-    snappy: '>=1.2.2,<1.3.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-24.0.0-hb646d72_7_cpu.conda
-  hash:
-    md5: 955fc6cc7d4dad4bdcc792141a43b5cb
-    sha256: 5bb6b744f6f488ea75f9161175dc1740a8e5bc4bf4201bf4b84e5f4138414c78
-  category: container
-  optional: true
-- name: libarrow
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
-    aws-sdk-cpp: '>=1.11.747,<1.11.748.0a0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-identity-cpp: '>=1.13.3,<1.13.4.0a0'
-    azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
-    azure-storage-files-datalake-cpp: '>=12.16.0,<12.16.1.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    glog: '>=0.7.1,<0.8.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libgcc: '>=14'
-    libgoogle-cloud: '>=3.5.0,<3.6.0a0'
-    libgoogle-cloud-storage: '>=3.5.0,<3.6.0a0'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    orc: '>=2.3.0,<2.3.1.0a0'
-    snappy: '>=1.2.2,<1.3.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-24.0.0-hb646d72_7_cpu.conda
-  hash:
-    md5: 955fc6cc7d4dad4bdcc792141a43b5cb
-    sha256: 5bb6b744f6f488ea75f9161175dc1740a8e5bc4bf4201bf4b84e5f4138414c78
-  category: notebooks
-  optional: true
-- name: libarrow
-  version: 24.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
-    aws-sdk-cpp: '>=1.11.747,<1.11.748.0a0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-identity-cpp: '>=1.13.3,<1.13.4.0a0'
-    azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
-    azure-storage-files-datalake-cpp: '>=12.16.0,<12.16.1.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    glog: '>=0.7.1,<0.8.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libgcc: '>=14'
-    libgoogle-cloud: '>=3.5.0,<3.6.0a0'
-    libgoogle-cloud-storage: '>=3.5.0,<3.6.0a0'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    orc: '>=2.3.0,<2.3.1.0a0'
-    snappy: '>=1.2.2,<1.3.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-24.0.0-h2ee4372_7_cpu.conda
-  hash:
-    md5: e88789070cd3059a7f828f772375eb3c
-    sha256: b6bdd1320c6a8c718adcedc4eb5d285a2d7b4a73ab0650fb36ddf01ed19cf065
-  category: container
-  optional: true
-- name: libarrow
-  version: 24.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
-    aws-sdk-cpp: '>=1.11.747,<1.11.748.0a0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-identity-cpp: '>=1.13.3,<1.13.4.0a0'
-    azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
-    azure-storage-files-datalake-cpp: '>=12.16.0,<12.16.1.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    glog: '>=0.7.1,<0.8.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libgcc: '>=14'
-    libgoogle-cloud: '>=3.5.0,<3.6.0a0'
-    libgoogle-cloud-storage: '>=3.5.0,<3.6.0a0'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    orc: '>=2.3.0,<2.3.1.0a0'
-    snappy: '>=1.2.2,<1.3.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-24.0.0-h2ee4372_7_cpu.conda
-  hash:
-    md5: e88789070cd3059a7f828f772375eb3c
-    sha256: b6bdd1320c6a8c718adcedc4eb5d285a2d7b4a73ab0650fb36ddf01ed19cf065
-  category: notebooks
-  optional: true
-- name: libarrow
-  version: 24.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
-    aws-sdk-cpp: '>=1.11.747,<1.11.748.0a0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-identity-cpp: '>=1.13.3,<1.13.4.0a0'
-    azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
-    azure-storage-files-datalake-cpp: '>=12.16.0,<12.16.1.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    glog: '>=0.7.1,<0.8.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libcxx: '>=21'
-    libgoogle-cloud: '>=3.5.0,<3.6.0a0'
-    libgoogle-cloud-storage: '>=3.5.0,<3.6.0a0'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    orc: '>=2.3.0,<2.3.1.0a0'
-    snappy: '>=1.2.2,<1.3.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-24.0.0-hf9fdb71_7_cpu.conda
-  hash:
-    md5: e8dd2a086d53bd982793102512c89982
-    sha256: acaa55957d26f70a34a1805beef8ab15e33eab273bfe0f848bd1788a9664fbc1
-  category: container
-  optional: true
-- name: libarrow
-  version: 24.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
-    aws-sdk-cpp: '>=1.11.747,<1.11.748.0a0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-identity-cpp: '>=1.13.3,<1.13.4.0a0'
-    azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
-    azure-storage-files-datalake-cpp: '>=12.16.0,<12.16.1.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    glog: '>=0.7.1,<0.8.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libcxx: '>=21'
-    libgoogle-cloud: '>=3.5.0,<3.6.0a0'
-    libgoogle-cloud-storage: '>=3.5.0,<3.6.0a0'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    orc: '>=2.3.0,<2.3.1.0a0'
-    snappy: '>=1.2.2,<1.3.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-24.0.0-hf9fdb71_7_cpu.conda
-  hash:
-    md5: e8dd2a086d53bd982793102512c89982
-    sha256: acaa55957d26f70a34a1805beef8ab15e33eab273bfe0f848bd1788a9664fbc1
-  category: notebooks
-  optional: true
-- name: libarrow
-  version: 24.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
-    aws-sdk-cpp: '>=1.11.747,<1.11.748.0a0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-identity-cpp: '>=1.13.3,<1.13.4.0a0'
-    azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
-    azure-storage-files-datalake-cpp: '>=12.16.0,<12.16.1.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    glog: '>=0.7.1,<0.8.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libcxx: '>=21'
-    libgoogle-cloud: '>=3.5.0,<3.6.0a0'
-    libgoogle-cloud-storage: '>=3.5.0,<3.6.0a0'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    orc: '>=2.3.0,<2.3.1.0a0'
-    snappy: '>=1.2.2,<1.3.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-24.0.0-h1caba66_7_cpu.conda
-  hash:
-    md5: 8c0da832fe315fa6dbb54eb02d540441
-    sha256: f9a33a46a7d7137dfdc0f9411cfeae451d1c7ed1f05211dbca8d8e189cfafa28
-  category: container
-  optional: true
-- name: libarrow
-  version: 24.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
-    aws-sdk-cpp: '>=1.11.747,<1.11.748.0a0'
-    azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
-    azure-identity-cpp: '>=1.13.3,<1.13.4.0a0'
-    azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
-    azure-storage-files-datalake-cpp: '>=12.16.0,<12.16.1.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    glog: '>=0.7.1,<0.8.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libcxx: '>=21'
-    libgoogle-cloud: '>=3.5.0,<3.6.0a0'
-    libgoogle-cloud-storage: '>=3.5.0,<3.6.0a0'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    orc: '>=2.3.0,<2.3.1.0a0'
-    snappy: '>=1.2.2,<1.3.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-24.0.0-h1caba66_7_cpu.conda
-  hash:
-    md5: 8c0da832fe315fa6dbb54eb02d540441
-    sha256: f9a33a46a7d7137dfdc0f9411cfeae451d1c7ed1f05211dbca8d8e189cfafa28
-  category: notebooks
-  optional: true
-- name: libarrow-acero
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libarrow: 24.0.0
-    libarrow-compute: 24.0.0
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-24.0.0-h635bf11_7_cpu.conda
-  hash:
-    md5: ac99e1831a4e498755a32d72820e44db
-    sha256: 3e84d52908eb55a17dd3e907b195246ccfaef3171107e67b107be11c5c137f27
-  category: container
-  optional: true
-- name: libarrow-acero
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libarrow: 24.0.0
-    libarrow-compute: 24.0.0
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-24.0.0-h635bf11_7_cpu.conda
-  hash:
-    md5: ac99e1831a4e498755a32d72820e44db
-    sha256: 3e84d52908eb55a17dd3e907b195246ccfaef3171107e67b107be11c5c137f27
-  category: notebooks
-  optional: true
-- name: libarrow-acero
-  version: 24.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libarrow: 24.0.0
-    libarrow-compute: 24.0.0
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-acero-24.0.0-hb326ee9_7_cpu.conda
-  hash:
-    md5: 984d07bb524d80e5be4ee855d9615ff2
-    sha256: 74d9e4668a7a5250d06123f05a38e86f4da86b286106b61204ebc6471b8b411b
-  category: container
-  optional: true
-- name: libarrow-acero
-  version: 24.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libarrow: 24.0.0
-    libarrow-compute: 24.0.0
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-acero-24.0.0-hb326ee9_7_cpu.conda
-  hash:
-    md5: 984d07bb524d80e5be4ee855d9615ff2
-    sha256: 74d9e4668a7a5250d06123f05a38e86f4da86b286106b61204ebc6471b8b411b
-  category: notebooks
-  optional: true
-- name: libarrow-acero
-  version: 24.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libarrow-compute: 24.0.0
-    libcxx: '>=21'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-24.0.0-h91633f5_7_cpu.conda
-  hash:
-    md5: 63c0bde25b99d990e13198b0569e7da7
-    sha256: 59652af9a33aa1549ac4b2ac2434f0ab2eb84ff73fe41901f1f7e6ee7de6a8ab
-  category: container
-  optional: true
-- name: libarrow-acero
-  version: 24.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libarrow-compute: 24.0.0
-    libcxx: '>=21'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-24.0.0-h91633f5_7_cpu.conda
-  hash:
-    md5: 63c0bde25b99d990e13198b0569e7da7
-    sha256: 59652af9a33aa1549ac4b2ac2434f0ab2eb84ff73fe41901f1f7e6ee7de6a8ab
-  category: notebooks
-  optional: true
-- name: libarrow-acero
-  version: 24.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libarrow-compute: 24.0.0
-    libcxx: '>=21'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-24.0.0-ha4f4840_7_cpu.conda
-  hash:
-    md5: f76650b0e81e5afdc84cf38647ebc3e4
-    sha256: c990529616309850ec3b5ceb14fe51710ec787528423a3c87a2bc27922623ec1
-  category: container
-  optional: true
-- name: libarrow-acero
-  version: 24.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libarrow-compute: 24.0.0
-    libcxx: '>=21'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-24.0.0-ha4f4840_7_cpu.conda
-  hash:
-    md5: f76650b0e81e5afdc84cf38647ebc3e4
-    sha256: c990529616309850ec3b5ceb14fe51710ec787528423a3c87a2bc27922623ec1
-  category: notebooks
-  optional: true
-- name: libarrow-compute
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libarrow: 24.0.0
-    libgcc: '>=14'
-    libre2-11: '>=2025.11.5'
-    libstdcxx: '>=14'
-    libutf8proc: '>=2.11.3,<2.12.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-compute-24.0.0-h53684a4_7_cpu.conda
-  hash:
-    md5: d96583ed99278f50296ebbe220e23f0b
-    sha256: 50bf05387ebef61649521a6e1a8fb9a666f0b3cb317ef99a239a8ed0f29c73fb
-  category: container
-  optional: true
-- name: libarrow-compute
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libarrow: 24.0.0
-    libgcc: '>=14'
-    libre2-11: '>=2025.11.5'
-    libstdcxx: '>=14'
-    libutf8proc: '>=2.11.3,<2.12.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-compute-24.0.0-h53684a4_7_cpu.conda
-  hash:
-    md5: d96583ed99278f50296ebbe220e23f0b
-    sha256: 50bf05387ebef61649521a6e1a8fb9a666f0b3cb317ef99a239a8ed0f29c73fb
-  category: notebooks
-  optional: true
-- name: libarrow-compute
-  version: 24.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libarrow: 24.0.0
-    libgcc: '>=14'
-    libre2-11: '>=2025.11.5'
-    libstdcxx: '>=14'
-    libutf8proc: '>=2.11.3,<2.12.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-compute-24.0.0-hdd99842_7_cpu.conda
-  hash:
-    md5: 40db4f9aa50867f2564dd63e86e3322d
-    sha256: b6515e6f4c1c3457de785578223c1ae62878ea286766104c591675de3c89e22f
-  category: container
-  optional: true
-- name: libarrow-compute
-  version: 24.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libarrow: 24.0.0
-    libgcc: '>=14'
-    libre2-11: '>=2025.11.5'
-    libstdcxx: '>=14'
-    libutf8proc: '>=2.11.3,<2.12.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-compute-24.0.0-hdd99842_7_cpu.conda
-  hash:
-    md5: 40db4f9aa50867f2564dd63e86e3322d
-    sha256: b6515e6f4c1c3457de785578223c1ae62878ea286766104c591675de3c89e22f
-  category: notebooks
-  optional: true
-- name: libarrow-compute
-  version: 24.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libcxx: '>=21'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libre2-11: '>=2025.11.5'
-    libutf8proc: '>=2.11.3,<2.12.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-compute-24.0.0-hb38465b_7_cpu.conda
-  hash:
-    md5: 350e4a18d883c23f55782be4ad41d5dd
-    sha256: edfea918f6c999dec73c275a773912a0d16f3262684516e28b5411f4c6be7c93
-  category: container
-  optional: true
-- name: libarrow-compute
-  version: 24.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libcxx: '>=21'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libre2-11: '>=2025.11.5'
-    libutf8proc: '>=2.11.3,<2.12.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-compute-24.0.0-hb38465b_7_cpu.conda
-  hash:
-    md5: 350e4a18d883c23f55782be4ad41d5dd
-    sha256: edfea918f6c999dec73c275a773912a0d16f3262684516e28b5411f4c6be7c93
-  category: notebooks
-  optional: true
-- name: libarrow-compute
-  version: 24.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libcxx: '>=21'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libre2-11: '>=2025.11.5'
-    libutf8proc: '>=2.11.3,<2.12.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-compute-24.0.0-h8d10c55_7_cpu.conda
-  hash:
-    md5: f3c8ab2c55e91c32df74428ff8c24468
-    sha256: ee2efa4ee262f8d2dbef81e37bbc018980dd7b85fc68e118e4f2b7c1b2500772
-  category: container
-  optional: true
-- name: libarrow-compute
-  version: 24.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libcxx: '>=21'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libre2-11: '>=2025.11.5'
-    libutf8proc: '>=2.11.3,<2.12.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-compute-24.0.0-h8d10c55_7_cpu.conda
-  hash:
-    md5: f3c8ab2c55e91c32df74428ff8c24468
-    sha256: ee2efa4ee262f8d2dbef81e37bbc018980dd7b85fc68e118e4f2b7c1b2500772
-  category: notebooks
-  optional: true
-- name: libarrow-dataset
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libarrow: 24.0.0
-    libarrow-acero: 24.0.0
-    libarrow-compute: 24.0.0
-    libgcc: '>=14'
-    libparquet: 24.0.0
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-24.0.0-h635bf11_7_cpu.conda
-  hash:
-    md5: 930d75defa0600cc52704fbedb0e4280
-    sha256: 9fd49a3532788e06ccbae5993005bafe2998ffcc3a33a0b42764590070b0ac12
-  category: container
-  optional: true
-- name: libarrow-dataset
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libarrow: 24.0.0
-    libarrow-acero: 24.0.0
-    libarrow-compute: 24.0.0
-    libgcc: '>=14'
-    libparquet: 24.0.0
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-24.0.0-h635bf11_7_cpu.conda
-  hash:
-    md5: 930d75defa0600cc52704fbedb0e4280
-    sha256: 9fd49a3532788e06ccbae5993005bafe2998ffcc3a33a0b42764590070b0ac12
-  category: notebooks
-  optional: true
-- name: libarrow-dataset
-  version: 24.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libarrow: 24.0.0
-    libarrow-acero: 24.0.0
-    libarrow-compute: 24.0.0
-    libgcc: '>=14'
-    libparquet: 24.0.0
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-dataset-24.0.0-hb326ee9_7_cpu.conda
-  hash:
-    md5: d2f6d96d854849245797363cd8c6c785
-    sha256: 0345692cdbf3276852359df59545e46c1c4c7b5f04cc90e4b4cc7870cb7b611c
-  category: container
-  optional: true
-- name: libarrow-dataset
-  version: 24.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libarrow: 24.0.0
-    libarrow-acero: 24.0.0
-    libarrow-compute: 24.0.0
-    libgcc: '>=14'
-    libparquet: 24.0.0
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-dataset-24.0.0-hb326ee9_7_cpu.conda
-  hash:
-    md5: d2f6d96d854849245797363cd8c6c785
-    sha256: 0345692cdbf3276852359df59545e46c1c4c7b5f04cc90e4b4cc7870cb7b611c
-  category: notebooks
-  optional: true
-- name: libarrow-dataset
-  version: 24.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libarrow-acero: 24.0.0
-    libarrow-compute: 24.0.0
-    libcxx: '>=21'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libparquet: 24.0.0
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-24.0.0-h91633f5_7_cpu.conda
-  hash:
-    md5: 3905be162b0965aad08f0b610a38bf9f
-    sha256: af341020d88b09d5accb8c8311a549c5c0b9e242f0f025c0e908f39da11d0de5
-  category: container
-  optional: true
-- name: libarrow-dataset
-  version: 24.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libarrow-acero: 24.0.0
-    libarrow-compute: 24.0.0
-    libcxx: '>=21'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libparquet: 24.0.0
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-24.0.0-h91633f5_7_cpu.conda
-  hash:
-    md5: 3905be162b0965aad08f0b610a38bf9f
-    sha256: af341020d88b09d5accb8c8311a549c5c0b9e242f0f025c0e908f39da11d0de5
-  category: notebooks
-  optional: true
-- name: libarrow-dataset
-  version: 24.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libarrow-acero: 24.0.0
-    libarrow-compute: 24.0.0
-    libcxx: '>=21'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libparquet: 24.0.0
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-24.0.0-ha4f4840_7_cpu.conda
-  hash:
-    md5: 7fbefdfed50106cad702c996715e3167
-    sha256: 2be94c8f7710ac5aea5ca523c8231f8134e69afc5851b135856a0fbfac0627df
-  category: container
-  optional: true
-- name: libarrow-dataset
-  version: 24.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libarrow-acero: 24.0.0
-    libarrow-compute: 24.0.0
-    libcxx: '>=21'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libparquet: 24.0.0
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-24.0.0-ha4f4840_7_cpu.conda
-  hash:
-    md5: 7fbefdfed50106cad702c996715e3167
-    sha256: 2be94c8f7710ac5aea5ca523c8231f8134e69afc5851b135856a0fbfac0627df
-  category: notebooks
-  optional: true
-- name: libarrow-substrait
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libarrow-acero: 24.0.0
-    libarrow-dataset: 24.0.0
-    libgcc: '>=14'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-24.0.0-hb4dd7c2_7_cpu.conda
-  hash:
-    md5: bb59cc5c481ef1c15212c303e15489b3
-    sha256: a1f2909056c3535a5408cd1b60c1f6b90f92817a205ea3ff8e2aec42da9856f6
-  category: container
-  optional: true
-- name: libarrow-substrait
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libarrow-acero: 24.0.0
-    libarrow-dataset: 24.0.0
-    libgcc: '>=14'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-24.0.0-hb4dd7c2_7_cpu.conda
-  hash:
-    md5: bb59cc5c481ef1c15212c303e15489b3
-    sha256: a1f2909056c3535a5408cd1b60c1f6b90f92817a205ea3ff8e2aec42da9856f6
-  category: notebooks
-  optional: true
-- name: libarrow-substrait
-  version: 24.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libarrow-acero: 24.0.0
-    libarrow-dataset: 24.0.0
-    libgcc: '>=14'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-substrait-24.0.0-hf29bd21_7_cpu.conda
-  hash:
-    md5: 6bea59008142d338159202016d2387c8
-    sha256: e4ce3a40c7bb7c2df5a71a47863285ef05322df80730813a7c54df703890e909
-  category: container
-  optional: true
-- name: libarrow-substrait
-  version: 24.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libarrow-acero: 24.0.0
-    libarrow-dataset: 24.0.0
-    libgcc: '>=14'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-substrait-24.0.0-hf29bd21_7_cpu.conda
-  hash:
-    md5: 6bea59008142d338159202016d2387c8
-    sha256: e4ce3a40c7bb7c2df5a71a47863285ef05322df80730813a7c54df703890e909
-  category: notebooks
-  optional: true
-- name: libarrow-substrait
-  version: 24.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libarrow-acero: 24.0.0
-    libarrow-dataset: 24.0.0
-    libcxx: '>=21'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-24.0.0-h613493e_7_cpu.conda
-  hash:
-    md5: 936820b1c781e6e73287d5f73a6e2000
-    sha256: fa77603b9094f4b19a1edcac5f9179b45193fa2995554e9bb7549691d3a2f0f3
-  category: container
-  optional: true
-- name: libarrow-substrait
-  version: 24.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libarrow-acero: 24.0.0
-    libarrow-dataset: 24.0.0
-    libcxx: '>=21'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-24.0.0-h613493e_7_cpu.conda
-  hash:
-    md5: 936820b1c781e6e73287d5f73a6e2000
-    sha256: fa77603b9094f4b19a1edcac5f9179b45193fa2995554e9bb7549691d3a2f0f3
-  category: notebooks
-  optional: true
-- name: libarrow-substrait
-  version: 24.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libarrow-acero: 24.0.0
-    libarrow-dataset: 24.0.0
-    libcxx: '>=21'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-24.0.0-h05be00f_7_cpu.conda
-  hash:
-    md5: 46fa6fe2ecf18c912d4e39bbcc39df2c
-    sha256: 49cdd6974804c0b8848da7eafb01d252cbd72164ab9a8007c8b08a54e3b98d87
-  category: container
-  optional: true
-- name: libarrow-substrait
-  version: 24.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libarrow-acero: 24.0.0
-    libarrow-dataset: 24.0.0
-    libcxx: '>=21'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-24.0.0-h05be00f_7_cpu.conda
-  hash:
-    md5: 46fa6fe2ecf18c912d4e39bbcc39df2c
-    sha256: 49cdd6974804c0b8848da7eafb01d252cbd72164ab9a8007c8b08a54e3b98d87
+    md5: cfa10f3c4b14c13f676dc08e2ea29023
+    sha256: 05c370fae4f2a5fd7baf59c15d75caec718d785ec47e813dbf7bff68355e4bb7
   category: notebooks
   optional: true
 - name: libblas
@@ -18921,31 +15860,27 @@ package:
   category: notebooks
   optional: true
 - name: libblas
-  version: 3.11.0
+  version: 3.9.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=11.0'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.11.0-8_h5cf9dc6_accelerate.conda
+    mkl: '>=2023.2.0,<2024.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-20_osx64_mkl.conda
   hash:
-    md5: d517f899d63de9d7837753bfce18a931
-    sha256: b65fbc12951175be44b01022563b960df46a1a1bcc81bed9224a2efcde9aaee2
+    md5: 160fdc97a51d66d51dc782fb67d35205
+    sha256: 808742b95f44dcc7c546e5c3bb7ed378b08aeaef3ee451d31dfe26cdf76d109f
   category: container
   optional: true
 - name: libblas
-  version: 3.11.0
+  version: 3.9.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=11.0'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.11.0-8_h5cf9dc6_accelerate.conda
+    mkl: '>=2023.2.0,<2024.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-20_osx64_mkl.conda
   hash:
-    md5: d517f899d63de9d7837753bfce18a931
-    sha256: b65fbc12951175be44b01022563b960df46a1a1bcc81bed9224a2efcde9aaee2
+    md5: 160fdc97a51d66d51dc782fb67d35205
+    sha256: 808742b95f44dcc7c546e5c3bb7ed378b08aeaef3ee451d31dfe26cdf76d109f
   category: notebooks
   optional: true
 - name: libblas
@@ -18953,13 +15888,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h3d1d584_accelerate.conda
+    libopenblas: '>=0.3.33,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
   hash:
-    md5: 38cc5133cd1a83fa70ea930999050f26
-    sha256: 0882a5c6eebdd0fbbb82ebd8b569f8c33e03b3f54acf7e77eafbe588b15e38a5
+    md5: dbfe729181a32741ae63ecb41eefbac6
+    sha256: 8f5ec18ead0619a9cf0f38b49796c22f6fc0f44850c0df2baea0f5277db16e75
   category: container
   optional: true
 - name: libblas
@@ -18967,27 +15900,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h3d1d584_accelerate.conda
+    libopenblas: '>=0.3.33,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
   hash:
-    md5: 38cc5133cd1a83fa70ea930999050f26
-    sha256: 0882a5c6eebdd0fbbb82ebd8b569f8c33e03b3f54acf7e77eafbe588b15e38a5
+    md5: dbfe729181a32741ae63ecb41eefbac6
+    sha256: 8f5ec18ead0619a9cf0f38b49796c22f6fc0f44850c0df2baea0f5277db16e75
   category: notebooks
-  optional: true
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
-  hash:
-    md5: 72c8fd1af66bd67bf580645b426513ed
-    sha256: 318f36bd49ca8ad85e6478bd8506c88d82454cc008c1ac1c6bf00a3c42fa610e
-  category: container
   optional: true
 - name: libbrotlicommon
   version: 1.2.0
@@ -19012,31 +15930,7 @@ package:
   hash:
     md5: 8ec1d03f3000108899d1799d9964f281
     sha256: 5fa8c163c8d776503aa68cdaf798ff9440c76a0a1c3ea84e0c43dbf1ece8af4d
-  category: container
-  optional: true
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlicommon-1.2.0-he30d5cf_1.conda
-  hash:
-    md5: 8ec1d03f3000108899d1799d9964f281
-    sha256: 5fa8c163c8d776503aa68cdaf798ff9440c76a0a1c3ea84e0c43dbf1ece8af4d
   category: notebooks
-  optional: true
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-h8616949_1.conda
-  hash:
-    md5: f157c098841474579569c85a60ece586
-    sha256: 4c19b211b3095f541426d5a9abac63e96a5045e509b3d11d4f9482de53efe43b
-  category: container
   optional: true
 - name: libbrotlicommon
   version: 1.2.0
@@ -19060,33 +15954,7 @@ package:
   hash:
     md5: 006e7ddd8a110771134fcc4e1e3a6ffa
     sha256: a7cb9e660531cf6fbd4148cff608c85738d0b76f0975c5fc3e7d5e92840b7229
-  category: container
-  optional: true
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
-  hash:
-    md5: 006e7ddd8a110771134fcc4e1e3a6ffa
-    sha256: a7cb9e660531cf6fbd4148cff608c85738d0b76f0975c5fc3e7d5e92840b7229
   category: notebooks
-  optional: true
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libbrotlicommon: 1.2.0
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
-  hash:
-    md5: 366b40a69f0ad6072561c1d09301c886
-    sha256: 12fff21d38f98bc446d82baa890e01fd82e3b750378fedc720ff93522ffb752b
-  category: container
   optional: true
 - name: libbrotlidec
   version: 1.2.0
@@ -19113,19 +15981,6 @@ package:
   hash:
     md5: 47e5b71b77bb8b47b4ecf9659492977f
     sha256: 494365e8f58799ea95a6e82334ef696e9c2120aecd6626121694b30a15033301
-  category: container
-  optional: true
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libbrotlicommon: 1.2.0
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlidec-1.2.0-he30d5cf_1.conda
-  hash:
-    md5: 47e5b71b77bb8b47b4ecf9659492977f
-    sha256: 494365e8f58799ea95a6e82334ef696e9c2120aecd6626121694b30a15033301
   category: notebooks
   optional: true
 - name: libbrotlidec
@@ -19139,33 +15994,7 @@ package:
   hash:
     md5: 63186ac7a8a24b3528b4b14f21c03f54
     sha256: 729158be90ae655a4e0427fe4079767734af1f9b69ff58cf94ca6e8d4b3eb4b7
-  category: container
-  optional: true
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h8616949_1.conda
-  hash:
-    md5: 63186ac7a8a24b3528b4b14f21c03f54
-    sha256: 729158be90ae655a4e0427fe4079767734af1f9b69ff58cf94ca6e8d4b3eb4b7
   category: notebooks
-  optional: true
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-hc919400_1.conda
-  hash:
-    md5: 079e88933963f3f149054eec2c487bc2
-    sha256: 2eae444039826db0454b19b52a3390f63bfe24f6b3e63089778dd5a5bf48b6bf
-  category: container
   optional: true
 - name: libbrotlidec
   version: 1.2.0
@@ -19192,34 +16021,7 @@ package:
   hash:
     md5: 4ffbb341c8b616aa2494b6afb26a0c5f
     sha256: a0c15c79997820bbd3fbc8ecf146f4fe0eca36cc60b62b63ac6cf78857f1dd0d
-  category: container
-  optional: true
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libbrotlicommon: 1.2.0
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
-  hash:
-    md5: 4ffbb341c8b616aa2494b6afb26a0c5f
-    sha256: a0c15c79997820bbd3fbc8ecf146f4fe0eca36cc60b62b63ac6cf78857f1dd0d
   category: notebooks
-  optional: true
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libbrotlicommon: 1.2.0
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlienc-1.2.0-he30d5cf_1.conda
-  hash:
-    md5: 6553a5d017fe14859ea8a4e6ea5def8f
-    sha256: f998c03257b9aa1f7464446af2cf424862f0e54258a2a588309853e45ae771df
-  category: container
   optional: true
 - name: libbrotlienc
   version: 1.2.0
@@ -19245,33 +16047,7 @@ package:
   hash:
     md5: 12a58fd3fc285ce20cf20edf21a0ff8f
     sha256: 8ece7b41b6548d6601ac2c2cd605cf2261268fc4443227cc284477ed23fbd401
-  category: container
-  optional: true
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h8616949_1.conda
-  hash:
-    md5: 12a58fd3fc285ce20cf20edf21a0ff8f
-    sha256: 8ece7b41b6548d6601ac2c2cd605cf2261268fc4443227cc284477ed23fbd401
   category: notebooks
-  optional: true
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-hc919400_1.conda
-  hash:
-    md5: b2b7c8288ca1a2d71ff97a8e6a1e8883
-    sha256: 01436c32bb41f9cb4bcf07dda647ce4e5deb8307abfc3abdc8da5317db8189d1
-  category: container
   optional: true
 - name: libbrotlienc
   version: 1.2.0
@@ -19335,40 +16111,28 @@ package:
   category: notebooks
   optional: true
 - name: libcblas
-  version: 3.11.0
+  version: 3.9.0
   manager: conda
   platform: osx-64
   dependencies:
-    libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.11.0-8_ha11ac61_accelerate.conda
+    libblas: 3.9.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-20_osx64_mkl.conda
   hash:
-    md5: eae5bcb7028af39e4f6458f03824a274
-    sha256: 418cb72e87783b2d4b6e79808e45442c834fa803e1c05211295f38021c3e96a7
+    md5: 51089a4865eb4aec2bc5c7468bd07f9f
+    sha256: a35e3c8f0efee2bee8926cbbf23dcb36c9cfe3100690af3b86f933bab26c4eeb
   category: container
   optional: true
 - name: libcblas
-  version: 3.11.0
+  version: 3.9.0
   manager: conda
   platform: osx-64
   dependencies:
-    libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.11.0-8_ha11ac61_accelerate.conda
+    libblas: 3.9.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-20_osx64_mkl.conda
   hash:
-    md5: eae5bcb7028af39e4f6458f03824a274
-    sha256: 418cb72e87783b2d4b6e79808e45442c834fa803e1c05211295f38021c3e96a7
+    md5: 51089a4865eb4aec2bc5c7468bd07f9f
+    sha256: a35e3c8f0efee2bee8926cbbf23dcb36c9cfe3100690af3b86f933bab26c4eeb
   category: notebooks
-  optional: true
-- name: libcblas
-  version: 3.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_h752f6bc_accelerate.conda
-  hash:
-    md5: 169b3b3da92c0fed1454c4051dabaadd
-    sha256: 84a62507787e121b85998362816b2424d7f814cf6f8a22625fb636738788351e
-  category: container
   optional: true
 - name: libcblas
   version: 3.11.0
@@ -19376,114 +16140,26 @@ package:
   platform: osx-arm64
   dependencies:
     libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_h752f6bc_accelerate.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
   hash:
-    md5: 169b3b3da92c0fed1454c4051dabaadd
-    sha256: 84a62507787e121b85998362816b2424d7f814cf6f8a22625fb636738788351e
-  category: notebooks
-  optional: true
-- name: libcrc32c
-  version: 1.1.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.4.0'
-    libstdcxx-ng: '>=9.4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
-  hash:
-    md5: c965a5aa0d5c1c37ffc62dff36e28400
-    sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
+    md5: 03a2ef3491da9e5b4d18c03e9f4b3109
+    sha256: f93efcd44bc24f97c2478c7474d3baa6801a057974f330e1d06bedc33e4c778f
   category: container
   optional: true
-- name: libcrc32c
-  version: 1.1.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.4.0'
-    libstdcxx-ng: '>=9.4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
-  hash:
-    md5: c965a5aa0d5c1c37ffc62dff36e28400
-    sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
-  category: notebooks
-  optional: true
-- name: libcrc32c
-  version: 1.1.2
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc-ng: '>=9.4.0'
-    libstdcxx-ng: '>=9.4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcrc32c-1.1.2-h01db608_0.tar.bz2
-  hash:
-    md5: 268ee639c17ada0002fb04dd21816cc2
-    sha256: b8b8c57a87da86b3ea24280fd6aa8efaf92f4e684b606bf2db5d3cb06ffbe2ea
-  category: container
-  optional: true
-- name: libcrc32c
-  version: 1.1.2
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc-ng: '>=9.4.0'
-    libstdcxx-ng: '>=9.4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcrc32c-1.1.2-h01db608_0.tar.bz2
-  hash:
-    md5: 268ee639c17ada0002fb04dd21816cc2
-    sha256: b8b8c57a87da86b3ea24280fd6aa8efaf92f4e684b606bf2db5d3cb06ffbe2ea
-  category: notebooks
-  optional: true
-- name: libcrc32c
-  version: 1.1.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libcxx: '>=11.1.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
-  hash:
-    md5: 23d6d5a69918a438355d7cbc4c3d54c9
-    sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
-  category: container
-  optional: true
-- name: libcrc32c
-  version: 1.1.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libcxx: '>=11.1.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
-  hash:
-    md5: 23d6d5a69918a438355d7cbc4c3d54c9
-    sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
-  category: notebooks
-  optional: true
-- name: libcrc32c
-  version: 1.1.2
+- name: libcblas
+  version: 3.11.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=11.1.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+    libblas: 3.11.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
   hash:
-    md5: 32bd82a6a625ea6ce090a81c3d34edeb
-    sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
-  category: container
-  optional: true
-- name: libcrc32c
-  version: 1.1.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libcxx: '>=11.1.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
-  hash:
-    md5: 32bd82a6a625ea6ce090a81c3d34edeb
-    sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
+    md5: 03a2ef3491da9e5b4d18c03e9f4b3109
+    sha256: f93efcd44bc24f97c2478c7474d3baa6801a057974f330e1d06bedc33e4c778f
   category: notebooks
   optional: true
 - name: libcurl
-  version: 8.20.0
+  version: 8.21.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -19493,35 +16169,16 @@ package:
     libnghttp2: '>=1.68.1,<2.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hcf29cc6_0.conda
   hash:
-    md5: c3cc2864f82a944bc90a7beb4d3b0e88
-    sha256: 75963a5dd913311f59a35dbd307592f4fa754c4808aff9c33edb430c415e38eb
-  category: container
-  optional: true
-- name: libcurl
-  version: 8.20.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    krb5: '>=1.22.2,<1.23.0a0'
-    libgcc: '>=14'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libssh2: '>=1.11.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
-  hash:
-    md5: c3cc2864f82a944bc90a7beb4d3b0e88
-    sha256: 75963a5dd913311f59a35dbd307592f4fa754c4808aff9c33edb430c415e38eb
+    md5: dcd79cabd5d435f48d75db3d81cb5874
+    sha256: 93ab25f02666eb8696fa70d9c920f2e3b370742ee17e2758705038a72e11147f
   category: notebooks
   optional: true
 - name: libcurl
-  version: 8.20.0
+  version: 8.21.0
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -19530,34 +16187,16 @@ package:
     libnghttp2: '>=1.68.1,<2.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.20.0-hc57f145_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-hc57f145_0.conda
   hash:
-    md5: 88da514c8db1a7f6a05297941a897af2
-    sha256: 1607d3caf58f7d9e9ad9e5f0841737d0cfa47b5501d4e36fbf98e1c645d7393e
-  category: container
-  optional: true
-- name: libcurl
-  version: 8.20.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    krb5: '>=1.22.2,<1.23.0a0'
-    libgcc: '>=14'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libssh2: '>=1.11.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.20.0-hc57f145_0.conda
-  hash:
-    md5: 88da514c8db1a7f6a05297941a897af2
-    sha256: 1607d3caf58f7d9e9ad9e5f0841737d0cfa47b5501d4e36fbf98e1c645d7393e
+    md5: 24e94f80c49aca799681ac65421d6920
+    sha256: 738dfa4f3b148f77656b3e13371dad2f57c320c762d90d0f1142039b53d07d41
   category: notebooks
   optional: true
 - name: libcurl
-  version: 8.20.0
+  version: 8.21.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -19566,34 +16205,16 @@ package:
     libnghttp2: '>=1.68.1,<2.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.20.0-h8f0b9e4_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.21.0-h8f0b9e4_0.conda
   hash:
-    md5: 4a0085ccf90dc514f0fc0909a874045e
-    sha256: 5d3d8a82ca43347e96f1d79048921f3a7c25e32514bc7feb53ed2a040dcca54d
-  category: container
-  optional: true
-- name: libcurl
-  version: 8.20.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    krb5: '>=1.22.2,<1.23.0a0'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libssh2: '>=1.11.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.20.0-h8f0b9e4_0.conda
-  hash:
-    md5: 4a0085ccf90dc514f0fc0909a874045e
-    sha256: 5d3d8a82ca43347e96f1d79048921f3a7c25e32514bc7feb53ed2a040dcca54d
+    md5: ee12fea9cd972edf0bd63f10a95f38d9
+    sha256: fb5220bd8254be0d18c119c2a39ee19fb41b7355062b4b808b5bb95bb69f139f
   category: notebooks
   optional: true
 - name: libcurl
-  version: 8.20.0
+  version: 8.21.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -19602,30 +16223,12 @@ package:
     libnghttp2: '>=1.68.1,<2.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.20.0-hd5a2499_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-hd5a2499_0.conda
   hash:
-    md5: 2f57b7d0c6adda88957586b7afd78438
-    sha256: 38c0bc634b61e542776e97cfd15d5d41edd304d4e47c333004d2d622439b2381
-  category: container
-  optional: true
-- name: libcurl
-  version: 8.20.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    krb5: '>=1.22.2,<1.23.0a0'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libssh2: '>=1.11.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.20.0-hd5a2499_0.conda
-  hash:
-    md5: 2f57b7d0c6adda88957586b7afd78438
-    sha256: 38c0bc634b61e542776e97cfd15d5d41edd304d4e47c333004d2d622439b2381
+    md5: 862eb5c81e1295f492fa261a68a4233f
+    sha256: 5f73f41b3504c9d41a60aa161f6c87c36f19f97c92b3510441db618e361dc946
   category: notebooks
   optional: true
 - name: libcxx
@@ -19735,32 +16338,7 @@ package:
   hash:
     md5: 6c77a605a7a689d17d4819c0f8ac9a00
     sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
-  category: container
-  optional: true
-- name: libdeflate
-  version: '1.25'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
-  hash:
-    md5: 6c77a605a7a689d17d4819c0f8ac9a00
-    sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
   category: notebooks
-  optional: true
-- name: libdeflate
-  version: '1.25'
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.25-h1af38f5_0.conda
-  hash:
-    md5: a9138815598fe6b91a1d6782ca657b0c
-    sha256: 48814b73bd462da6eed2e697e30c060ae16af21e9fbed30d64feaf0aad9da392
-  category: container
   optional: true
 - name: libdeflate
   version: '1.25'
@@ -19784,31 +16362,7 @@ package:
   hash:
     md5: 31aa65919a729dc48180893f62c25221
     sha256: 025f8b1e85dd8254e0ca65f011919fb1753070eb507f03bca317871a884d24de
-  category: container
-  optional: true
-- name: libdeflate
-  version: '1.25'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.25-h517ebb2_0.conda
-  hash:
-    md5: 31aa65919a729dc48180893f62c25221
-    sha256: 025f8b1e85dd8254e0ca65f011919fb1753070eb507f03bca317871a884d24de
   category: notebooks
-  optional: true
-- name: libdeflate
-  version: '1.25'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.25-hc11a715_0.conda
-  hash:
-    md5: a6130c709305cd9828b4e1bd9ba0000c
-    sha256: 5e0b6961be3304a5f027a8c00bd0967fc46ae162cffb7553ff45c70f51b8314c
-  category: container
   optional: true
 - name: libdeflate
   version: '1.25'
@@ -20044,31 +16598,7 @@ package:
   hash:
     md5: 172bf1cd1ff8629f2b1179945ed45055
     sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
-  category: container
-  optional: true
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
-  hash:
-    md5: 172bf1cd1ff8629f2b1179945ed45055
-    sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
   category: notebooks
-  optional: true
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
-  hash:
-    md5: a9a13cb143bbaa477b1ebaefbe47a302
-    sha256: 973af77e297f1955dd1f69c2cbdc5ab9dfc88388a5576cd152cda178af0fd006
-  category: container
   optional: true
 - name: libev
   version: '4.33'
@@ -20091,17 +16621,6 @@ package:
   hash:
     md5: 899db79329439820b7e8f8de41bca902
     sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
-  category: container
-  optional: true
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
-  hash:
-    md5: 899db79329439820b7e8f8de41bca902
-    sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
   category: notebooks
   optional: true
 - name: libev
@@ -20113,117 +16632,6 @@ package:
   hash:
     md5: 36d33e440c31857372a72137f78bacf5
     sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
-  category: container
-  optional: true
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
-  hash:
-    md5: 36d33e440c31857372a72137f78bacf5
-    sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
-  category: notebooks
-  optional: true
-- name: libevent
-  version: 2.1.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    openssl: '>=3.1.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
-  hash:
-    md5: a1cfcc585f0c42bf8d5546bb1dfb668d
-    sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
-  category: container
-  optional: true
-- name: libevent
-  version: 2.1.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    openssl: '>=3.1.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
-  hash:
-    md5: a1cfcc585f0c42bf8d5546bb1dfb668d
-    sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
-  category: notebooks
-  optional: true
-- name: libevent
-  version: 2.1.12
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc-ng: '>=12'
-    openssl: '>=3.1.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
-  hash:
-    md5: 96ae6083cd1ac9f6bc81631ac835b317
-    sha256: 01333cc7d6e6985dd5700b43660d90e9e58049182017fd24862088ecbe1458e4
-  category: container
-  optional: true
-- name: libevent
-  version: 2.1.12
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc-ng: '>=12'
-    openssl: '>=3.1.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
-  hash:
-    md5: 96ae6083cd1ac9f6bc81631ac835b317
-    sha256: 01333cc7d6e6985dd5700b43660d90e9e58049182017fd24862088ecbe1458e4
-  category: notebooks
-  optional: true
-- name: libevent
-  version: 2.1.12
-  manager: conda
-  platform: osx-64
-  dependencies:
-    openssl: '>=3.1.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
-  hash:
-    md5: e38e467e577bd193a7d5de7c2c540b04
-    sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
-  category: container
-  optional: true
-- name: libevent
-  version: 2.1.12
-  manager: conda
-  platform: osx-64
-  dependencies:
-    openssl: '>=3.1.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
-  hash:
-    md5: e38e467e577bd193a7d5de7c2c540b04
-    sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
-  category: notebooks
-  optional: true
-- name: libevent
-  version: 2.1.12
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    openssl: '>=3.1.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
-  hash:
-    md5: 1a109764bff3bdc7bdd84088347d71dc
-    sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
-  category: container
-  optional: true
-- name: libevent
-  version: 2.1.12
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    openssl: '>=3.1.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
-  hash:
-    md5: 1a109764bff3bdc7bdd84088347d71dc
-    sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
   category: notebooks
   optional: true
 - name: libexpat
@@ -20294,10 +16702,10 @@ package:
   platform: linux-aarch64
   dependencies:
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-hd65408f_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
   hash:
-    md5: 0c5ad486dcfb188885e3cf8ba209b97b
-    sha256: 6c3332e78a975e092e54f87771611db81dcb5515a3847a3641021621de76caea
+    md5: 2f364feefb6a7c00423e80dcb12db62a
+    sha256: 3df4c539449aabc3443bbe8c492c01d401eea894603087fca2917aa4e1c2dea9
   category: main
   optional: false
 - name: libffi
@@ -20318,222 +16726,12 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-he5f378a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
   hash:
-    md5: 411ff7cd5d1472bba0f55c0faf04453b
-    sha256: 9b8acdf42df61b7bfe8bdc545c016c29e61985e79748c64ad66df47dbc2e295f
+    md5: 43c04d9cb46ef176bb2a4c77e324d599
+    sha256: 6686a26466a527585e6a75cc2a242bf4a3d97d6d6c86424a441677917f28bec7
   category: main
   optional: false
-- name: libfreetype
-  version: 2.14.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libfreetype6: '>=2.14.3'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
-  hash:
-    md5: e289f3d17880e44b633ba911d57a321b
-    sha256: 38f014a7129e644636e46064ecd6b1945e729c2140e21d75bb476af39e692db2
-  category: container
-  optional: true
-- name: libfreetype
-  version: 2.14.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libfreetype6: '>=2.14.3'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
-  hash:
-    md5: e289f3d17880e44b633ba911d57a321b
-    sha256: 38f014a7129e644636e46064ecd6b1945e729c2140e21d75bb476af39e692db2
-  category: notebooks
-  optional: true
-- name: libfreetype
-  version: 2.14.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libfreetype6: '>=2.14.3'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
-  hash:
-    md5: a13e600f9d18488b1fd1257344dbfdaa
-    sha256: db75d0fc080992dc67db8e24d7bb2a2f2a0b25bfce8870fa45a82a4b5f6111a2
-  category: container
-  optional: true
-- name: libfreetype
-  version: 2.14.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libfreetype6: '>=2.14.3'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
-  hash:
-    md5: a13e600f9d18488b1fd1257344dbfdaa
-    sha256: db75d0fc080992dc67db8e24d7bb2a2f2a0b25bfce8870fa45a82a4b5f6111a2
-  category: notebooks
-  optional: true
-- name: libfreetype
-  version: 2.14.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libfreetype6: '>=2.14.3'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libfreetype-2.14.3-h694c41f_1.conda
-  hash:
-    md5: 7cec36e11e7c5a674a1d8c1d5082479e
-    sha256: 9029ed0c940be8161c86f5338eacfad1f61af216cdc508e386a648f6ef893a28
-  category: container
-  optional: true
-- name: libfreetype
-  version: 2.14.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libfreetype6: '>=2.14.3'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libfreetype-2.14.3-h694c41f_1.conda
-  hash:
-    md5: 7cec36e11e7c5a674a1d8c1d5082479e
-    sha256: 9029ed0c940be8161c86f5338eacfad1f61af216cdc508e386a648f6ef893a28
-  category: notebooks
-  optional: true
-- name: libfreetype
-  version: 2.14.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libfreetype6: '>=2.14.3'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
-  hash:
-    md5: 0582e67cd14cfed773be2f3b1aba08e0
-    sha256: d5637b01941c0fc8f5cbb1f170c238f4ee153b3c1708b9d50f4f1305438ff051
-  category: container
-  optional: true
-- name: libfreetype
-  version: 2.14.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libfreetype6: '>=2.14.3'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
-  hash:
-    md5: 0582e67cd14cfed773be2f3b1aba08e0
-    sha256: d5637b01941c0fc8f5cbb1f170c238f4ee153b3c1708b9d50f4f1305438ff051
-  category: notebooks
-  optional: true
-- name: libfreetype6
-  version: 2.14.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libpng: '>=1.6.55,<1.7.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
-  hash:
-    md5: fb16b4b69e3f1dcfe79d80db8fd0c55d
-    sha256: 16f020f96da79db1863fcdd8f2b8f4f7d52f177dd4c58601e38e9182e91adf1d
-  category: container
-  optional: true
-- name: libfreetype6
-  version: 2.14.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libpng: '>=1.6.55,<1.7.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
-  hash:
-    md5: fb16b4b69e3f1dcfe79d80db8fd0c55d
-    sha256: 16f020f96da79db1863fcdd8f2b8f4f7d52f177dd4c58601e38e9182e91adf1d
-  category: notebooks
-  optional: true
-- name: libfreetype6
-  version: 2.14.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libpng: '>=1.6.58,<1.7.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
-  hash:
-    md5: 426cc33f8745ce11a73baf73db3954a7
-    sha256: 34fe8276befd6c42956c4acd969caeddbdc7ea8e6ed054b8388709b6c3e94ba4
-  category: container
-  optional: true
-- name: libfreetype6
-  version: 2.14.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libpng: '>=1.6.58,<1.7.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
-  hash:
-    md5: 426cc33f8745ce11a73baf73db3954a7
-    sha256: 34fe8276befd6c42956c4acd969caeddbdc7ea8e6ed054b8388709b6c3e94ba4
-  category: notebooks
-  optional: true
-- name: libfreetype6
-  version: 2.14.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libpng: '>=1.6.58,<1.7.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libfreetype6-2.14.3-h58fbd8d_1.conda
-  hash:
-    md5: 112cb22521fa3abf19bc0c93938576f5
-    sha256: cc94862c51e68626fadddf68b523e5f752149186ccc498fa37976504e2e7ff55
-  category: container
-  optional: true
-- name: libfreetype6
-  version: 2.14.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libpng: '>=1.6.58,<1.7.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libfreetype6-2.14.3-h58fbd8d_1.conda
-  hash:
-    md5: 112cb22521fa3abf19bc0c93938576f5
-    sha256: cc94862c51e68626fadddf68b523e5f752149186ccc498fa37976504e2e7ff55
-  category: notebooks
-  optional: true
-- name: libfreetype6
-  version: 2.14.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libpng: '>=1.6.58,<1.7.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_1.conda
-  hash:
-    md5: a0bb0678f67c464938d3693fa96f6884
-    sha256: abbfffd8a8c776bb8b59a10c8247fc3aa6b17ba0051e9f6d199dca38479f214f
-  category: container
-  optional: true
-- name: libfreetype6
-  version: 2.14.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libpng: '>=1.6.58,<1.7.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_1.conda
-  hash:
-    md5: a0bb0678f67c464938d3693fa96f6884
-    sha256: abbfffd8a8c776bb8b59a10c8247fc3aa6b17ba0051e9f6d199dca38479f214f
-  category: notebooks
-  optional: true
 - name: libgcc
   version: 15.2.0
   manager: conda
@@ -20569,18 +16767,6 @@ package:
   hash:
     md5: 4bf33d5ca73f4b89d3495285a42414a4
     sha256: 17a5dcd818f89173db51d7d1acd77615cb77db7b4c2b5f571d4dafe559430ab5
-  category: container
-  optional: true
-- name: libgcc
-  version: 15.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    _openmp_mutex: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
-  hash:
-    md5: 4bf33d5ca73f4b89d3495285a42414a4
-    sha256: 17a5dcd818f89173db51d7d1acd77615cb77db7b4c2b5f571d4dafe559430ab5
   category: notebooks
   optional: true
 - name: libgcc
@@ -20617,31 +16803,7 @@ package:
   hash:
     md5: 331ee9b72b9dff570d56b1302c5ab37d
     sha256: 9dcf54adfaa5e861123c2da4f2f0451a685464ea7e5a41ad91cf67b31d658d98
-  category: container
-  optional: true
-- name: libgcc-ng
-  version: 15.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
-  hash:
-    md5: 331ee9b72b9dff570d56b1302c5ab37d
-    sha256: 9dcf54adfaa5e861123c2da4f2f0451a685464ea7e5a41ad91cf67b31d658d98
   category: notebooks
-  optional: true
-- name: libgcc-ng
-  version: 15.2.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
-  hash:
-    md5: 770cf892e5530f43e63cadc673e85653
-    sha256: 1137f93f477f56199ded24117430045a0c02cbe8b10031beac3b9ad2138539d3
-  category: container
   optional: true
 - name: libgcc-ng
   version: 15.2.0
@@ -20866,18 +17028,6 @@ package:
   hash:
     md5: d362f41203d0a1d2d4940446f95374c9
     sha256: 519045363b87b870be779d38f0bfd325d4b787acdaa0a2136a92c1081eff5112
-  category: container
-  optional: true
-- name: libgfortran
-  version: 15.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libgfortran5: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
-  hash:
-    md5: d362f41203d0a1d2d4940446f95374c9
-    sha256: 519045363b87b870be779d38f0bfd325d4b787acdaa0a2136a92c1081eff5112
   category: notebooks
   optional: true
 - name: libgfortran
@@ -20951,18 +17101,6 @@ package:
   hash:
     md5: 1cddb3f7e54f5871297afc0fafa61c2c
     sha256: c7f5f6e80357d6d5bc69588c16144205b0c79cf32cd090ccb5afef9d557632af
-  category: container
-  optional: true
-- name: libgfortran5
-  version: 15.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libgcc: '>=15.2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
-  hash:
-    md5: 1cddb3f7e54f5871297afc0fafa61c2c
-    sha256: c7f5f6e80357d6d5bc69588c16144205b0c79cf32cd090ccb5afef9d557632af
   category: notebooks
   optional: true
 - name: libgfortran5
@@ -20990,7 +17128,7 @@ package:
   category: notebooks
   optional: true
 - name: libglib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -21000,14 +17138,14 @@ package:
     libiconv: '>=1.18,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
   hash:
-    md5: 17d484ab9c8179c6a6e5b7dbb5065afc
-    sha256: 33eb5d5310a5c2c0a4707a0afa644801c2e08c8f70c45e1f62f354116dfe0970
+    md5: 889febc66cd9e4190f80ef9718fa239b
+    sha256: 4bee10e62796f01e4fa2b5849135b1cc061337fe9cf5eb9bd79e9664922ae0e4
   category: tools
   optional: true
 - name: libglib
-  version: 2.88.1
+  version: 2.88.2
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -21016,481 +17154,11 @@ package:
     libiconv: '>=1.18,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.88.1-h96a7f82_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.88.2-h96a7f82_0.conda
   hash:
-    md5: 16d72f76bf6fead4a29efb2fede0a06b
-    sha256: 050285afdb7bd98b1b8fb052af9da31fafde586a49d3b56dd33d5338b2d0e411
+    md5: 31d404d8c0755d0f9062a4459f5a1084
+    sha256: 6a13152a81513117b8d41bf64dea56c731d877bcced5a24fab738e3c0f9ac58c
   category: tools
-  optional: true
-- name: libgoogle-cloud
-  version: 3.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libgcc: '>=14'
-    libgrpc: '>=1.78.1,<1.79.0a0'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.5.0-h8d2ee43_1.conda
-  hash:
-    md5: 8ae0593085ca8148fdbf0bc8f62e79c1
-    sha256: 42c8ca362013d0378ba58afb61940d23c94e0f7127004190dcd12fe4a3072953
-  category: container
-  optional: true
-- name: libgoogle-cloud
-  version: 3.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libgcc: '>=14'
-    libgrpc: '>=1.78.1,<1.79.0a0'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.5.0-h8d2ee43_1.conda
-  hash:
-    md5: 8ae0593085ca8148fdbf0bc8f62e79c1
-    sha256: 42c8ca362013d0378ba58afb61940d23c94e0f7127004190dcd12fe4a3072953
-  category: notebooks
-  optional: true
-- name: libgoogle-cloud
-  version: 3.5.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libgcc: '>=14'
-    libgrpc: '>=1.78.1,<1.79.0a0'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgoogle-cloud-3.5.0-h235f271_1.conda
-  hash:
-    md5: a77d18215c61deb67579083a31e639da
-    sha256: 79f5badd9d3c3a700fc1eb9ee6409e521cada72caac05ab39670431a817603b7
-  category: container
-  optional: true
-- name: libgoogle-cloud
-  version: 3.5.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libgcc: '>=14'
-    libgrpc: '>=1.78.1,<1.79.0a0'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgoogle-cloud-3.5.0-h235f271_1.conda
-  hash:
-    md5: a77d18215c61deb67579083a31e639da
-    sha256: 79f5badd9d3c3a700fc1eb9ee6409e521cada72caac05ab39670431a817603b7
-  category: notebooks
-  optional: true
-- name: libgoogle-cloud
-  version: 3.5.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libcxx: '>=19'
-    libgrpc: '>=1.78.1,<1.79.0a0'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-3.5.0-h8b848e0_1.conda
-  hash:
-    md5: 323f0d14ccec33e69a6c16a11f3ec7c1
-    sha256: f6f23551b2f4b9c9b3e0c72398e4995702e832ee03b717e4d9802ce695f6938a
-  category: container
-  optional: true
-- name: libgoogle-cloud
-  version: 3.5.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libcxx: '>=19'
-    libgrpc: '>=1.78.1,<1.79.0a0'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-3.5.0-h8b848e0_1.conda
-  hash:
-    md5: 323f0d14ccec33e69a6c16a11f3ec7c1
-    sha256: f6f23551b2f4b9c9b3e0c72398e4995702e832ee03b717e4d9802ce695f6938a
-  category: notebooks
-  optional: true
-- name: libgoogle-cloud
-  version: 3.5.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libcxx: '>=19'
-    libgrpc: '>=1.78.1,<1.79.0a0'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.5.0-h688a705_1.conda
-  hash:
-    md5: 3899a5a69da373a85e7f53be3d32b814
-    sha256: 20235ded7b8d125461a9ed5e02f174eae89e85a271d3343167015f779ebc4714
-  category: container
-  optional: true
-- name: libgoogle-cloud
-  version: 3.5.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libcxx: '>=19'
-    libgrpc: '>=1.78.1,<1.79.0a0'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.5.0-h688a705_1.conda
-  hash:
-    md5: 3899a5a69da373a85e7f53be3d32b814
-    sha256: 20235ded7b8d125461a9ed5e02f174eae89e85a271d3343167015f779ebc4714
-  category: notebooks
-  optional: true
-- name: libgoogle-cloud-storage
-  version: 3.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libabseil: ''
-    libcrc32c: '>=1.1.2,<1.2.0a0'
-    libcurl: ''
-    libgcc: '>=14'
-    libgoogle-cloud: 3.5.0
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.5.0-hdbdcf42_1.conda
-  hash:
-    md5: 6f79d5f72cfcdd3509112233a8aedc2e
-    sha256: 6914f9b0f2d5bb0c5687b880c6c352a2333449d03ce80e6826230675062b57f1
-  category: container
-  optional: true
-- name: libgoogle-cloud-storage
-  version: 3.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libabseil: ''
-    libcrc32c: '>=1.1.2,<1.2.0a0'
-    libcurl: ''
-    libgcc: '>=14'
-    libgoogle-cloud: 3.5.0
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.5.0-hdbdcf42_1.conda
-  hash:
-    md5: 6f79d5f72cfcdd3509112233a8aedc2e
-    sha256: 6914f9b0f2d5bb0c5687b880c6c352a2333449d03ce80e6826230675062b57f1
-  category: notebooks
-  optional: true
-- name: libgoogle-cloud-storage
-  version: 3.5.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libabseil: ''
-    libcrc32c: '>=1.1.2,<1.2.0a0'
-    libcurl: ''
-    libgcc: '>=14'
-    libgoogle-cloud: 3.5.0
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: ''
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgoogle-cloud-storage-3.5.0-h66d5b86_1.conda
-  hash:
-    md5: ad8594a85c62901651be18963452d511
-    sha256: 140695b54b021b56f5aaffa1fc6ccb05566b475696fdc54e66aa144d51081a23
-  category: container
-  optional: true
-- name: libgoogle-cloud-storage
-  version: 3.5.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libabseil: ''
-    libcrc32c: '>=1.1.2,<1.2.0a0'
-    libcurl: ''
-    libgcc: '>=14'
-    libgoogle-cloud: 3.5.0
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: ''
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgoogle-cloud-storage-3.5.0-h66d5b86_1.conda
-  hash:
-    md5: ad8594a85c62901651be18963452d511
-    sha256: 140695b54b021b56f5aaffa1fc6ccb05566b475696fdc54e66aa144d51081a23
-  category: notebooks
-  optional: true
-- name: libgoogle-cloud-storage
-  version: 3.5.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: ''
-    libcrc32c: '>=1.1.2,<1.2.0a0'
-    libcurl: ''
-    libcxx: '>=19'
-    libgoogle-cloud: 3.5.0
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-3.5.0-hea209c6_1.conda
-  hash:
-    md5: 8c84b06d18a3c83c28eb89bca378daad
-    sha256: 086374067de8b3fd6198f87f8a7879d5042e35a7816e2a570155a3590e480a0d
-  category: container
-  optional: true
-- name: libgoogle-cloud-storage
-  version: 3.5.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: ''
-    libcrc32c: '>=1.1.2,<1.2.0a0'
-    libcurl: ''
-    libcxx: '>=19'
-    libgoogle-cloud: 3.5.0
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-3.5.0-hea209c6_1.conda
-  hash:
-    md5: 8c84b06d18a3c83c28eb89bca378daad
-    sha256: 086374067de8b3fd6198f87f8a7879d5042e35a7816e2a570155a3590e480a0d
-  category: notebooks
-  optional: true
-- name: libgoogle-cloud-storage
-  version: 3.5.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: ''
-    libcrc32c: '>=1.1.2,<1.2.0a0'
-    libcurl: ''
-    libcxx: '>=19'
-    libgoogle-cloud: 3.5.0
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.5.0-ha114238_1.conda
-  hash:
-    md5: ecc3983f92594b3863a7e5d47d1a71ba
-    sha256: 40b7074e3837fe3dcebef0e93f1f40fb995abd94787e51d231d31142e157dadd
-  category: container
-  optional: true
-- name: libgoogle-cloud-storage
-  version: 3.5.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: ''
-    libcrc32c: '>=1.1.2,<1.2.0a0'
-    libcurl: ''
-    libcxx: '>=19'
-    libgoogle-cloud: 3.5.0
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.5.0-ha114238_1.conda
-  hash:
-    md5: ecc3983f92594b3863a7e5d47d1a71ba
-    sha256: 40b7074e3837fe3dcebef0e93f1f40fb995abd94787e51d231d31142e157dadd
-  category: notebooks
-  optional: true
-- name: libgrpc
-  version: 1.78.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    c-ares: '>=1.34.6,<2.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libgcc: '>=14'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libre2-11: '>=2025.11.5'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.78.1-h1d1128b_0.conda
-  hash:
-    md5: b5fb6d6c83f63d83ef2721dca6ff7091
-    sha256: 5bb935188999fd70f67996746fd2dca85ec6204289e11695c316772e19451eb8
-  category: container
-  optional: true
-- name: libgrpc
-  version: 1.78.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    c-ares: '>=1.34.6,<2.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libgcc: '>=14'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libre2-11: '>=2025.11.5'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.78.1-h1d1128b_0.conda
-  hash:
-    md5: b5fb6d6c83f63d83ef2721dca6ff7091
-    sha256: 5bb935188999fd70f67996746fd2dca85ec6204289e11695c316772e19451eb8
-  category: notebooks
-  optional: true
-- name: libgrpc
-  version: 1.78.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    c-ares: '>=1.34.6,<2.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libgcc: '>=14'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libre2-11: '>=2025.11.5'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgrpc-1.78.1-heab1e18_0.conda
-  hash:
-    md5: c8ee69a26fce1cb948e7b8e559649d65
-    sha256: a9a7c7f788526479bc5e0ba6c6b4cb0e534dc259f75a8597917cc782d61d48ed
-  category: container
-  optional: true
-- name: libgrpc
-  version: 1.78.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    c-ares: '>=1.34.6,<2.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libgcc: '>=14'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libre2-11: '>=2025.11.5'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgrpc-1.78.1-heab1e18_0.conda
-  hash:
-    md5: c8ee69a26fce1cb948e7b8e559649d65
-    sha256: a9a7c7f788526479bc5e0ba6c6b4cb0e534dc259f75a8597917cc782d61d48ed
-  category: notebooks
-  optional: true
-- name: libgrpc
-  version: 1.78.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.6,<2.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcxx: '>=19'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libre2-11: '>=2025.11.5'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.78.1-h147dede_0.conda
-  hash:
-    md5: 69524227096cee1a8af2f4693cf6afa2
-    sha256: ecf98c41dbde09fb3bf6878d7099613c10e256223ec7ccdb5eb401948eadc558
-  category: container
-  optional: true
-- name: libgrpc
-  version: 1.78.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.6,<2.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcxx: '>=19'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libre2-11: '>=2025.11.5'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.78.1-h147dede_0.conda
-  hash:
-    md5: 69524227096cee1a8af2f4693cf6afa2
-    sha256: ecf98c41dbde09fb3bf6878d7099613c10e256223ec7ccdb5eb401948eadc558
-  category: notebooks
-  optional: true
-- name: libgrpc
-  version: 1.78.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.6,<2.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcxx: '>=19'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libre2-11: '>=2025.11.5'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
-  hash:
-    md5: 17b9e07ba9b46754a6953999a948dcf7
-    sha256: a6e01573795484c2200e499ddffb825d24184888be6a596d4beaceebe6f8f525
-  category: container
-  optional: true
-- name: libgrpc
-  version: 1.78.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.6,<2.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcxx: '>=19'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libre2-11: '>=2025.11.5'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
-  hash:
-    md5: 17b9e07ba9b46754a6953999a948dcf7
-    sha256: a6e01573795484c2200e499ddffb825d24184888be6a596d4beaceebe6f8f525
-  category: notebooks
   optional: true
 - name: libhwloc
   version: 2.13.0
@@ -21522,6 +17190,36 @@ package:
   hash:
     md5: c197985b58bc813d26b42881f0021c82
     sha256: 5041d295813dfb84652557839825880aae296222ab725972285c5abe3b6e4288
+  category: notebooks
+  optional: true
+- name: libhwloc
+  version: 2.13.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libcxx: '>=19'
+    libxml2: ''
+    libxml2-16: '>=2.14.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.13.0-default_h4e3125e_1000.conda
+  hash:
+    md5: c74c64d67f55426bc24d333a84aed0e3
+    sha256: 8e051b990da280ca6eca2f025640572459a0ddfa2b3b71a113e4d14b4277aa33
+  category: container
+  optional: true
+- name: libhwloc
+  version: 2.13.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libcxx: '>=19'
+    libxml2: ''
+    libxml2-16: '>=2.14.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.13.0-default_h4e3125e_1000.conda
+  hash:
+    md5: c74c64d67f55426bc24d333a84aed0e3
+    sha256: 8e051b990da280ca6eca2f025640572459a0ddfa2b3b71a113e4d14b4277aa33
   category: notebooks
   optional: true
 - name: libhwy
@@ -21626,18 +17324,6 @@ package:
   hash:
     md5: 5a86bf847b9b926f3a4f203339748d78
     sha256: 1473451cd282b48d24515795a595801c9b65b567fe399d7e12d50b2d6cdb04d9
-  category: container
-  optional: true
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
-  hash:
-    md5: 5a86bf847b9b926f3a4f203339748d78
-    sha256: 1473451cd282b48d24515795a595801c9b65b567fe399d7e12d50b2d6cdb04d9
   category: notebooks
   optional: true
 - name: libiconv
@@ -21686,32 +17372,7 @@ package:
   hash:
     md5: 4d5a7445f0b25b6a3ddbb56e790f5251
     sha256: de0336e800b2af9a40bdd694b03870ac4a848161b35c8a2325704f123f185f03
-  category: container
-  optional: true
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
-  hash:
-    md5: 4d5a7445f0b25b6a3ddbb56e790f5251
-    sha256: de0336e800b2af9a40bdd694b03870ac4a848161b35c8a2325704f123f185f03
   category: notebooks
-  optional: true
-- name: libjpeg-turbo
-  version: 3.1.4.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
-  hash:
-    md5: 6178c6f2fb254558238ef4e6c56fb782
-    sha256: 10056646c28115b174de81a44e23e3a0a3b95b5347d2e6c45cc6d49d35294256
-  category: container
   optional: true
 - name: libjpeg-turbo
   version: 3.1.4.1
@@ -21736,18 +17397,6 @@ package:
   hash:
     md5: a85ba48648f6868016f2741fd9170250
     sha256: e97ec2af5f09f8f6ea8ecd550055c95ae80fae22015fcfadaa94eafe025c9ccc
-  category: container
-  optional: true
-- name: libjpeg-turbo
-  version: 3.1.4.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.1.4.1-he30d5cf_0.conda
-  hash:
-    md5: a85ba48648f6868016f2741fd9170250
-    sha256: e97ec2af5f09f8f6ea8ecd550055c95ae80fae22015fcfadaa94eafe025c9ccc
   category: notebooks
   optional: true
 - name: libjpeg-turbo
@@ -21760,31 +17409,7 @@ package:
   hash:
     md5: 57cc1464d457d01ac78f5860b9ca1714
     sha256: 6b809d8acb6b97bbb1a858eb4ba7b7163c67257b6c3f199dd9d1e0751f4c5b18
-  category: container
-  optional: true
-- name: libjpeg-turbo
-  version: 3.1.4.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.1.4.1-ha1e9b39_0.conda
-  hash:
-    md5: 57cc1464d457d01ac78f5860b9ca1714
-    sha256: 6b809d8acb6b97bbb1a858eb4ba7b7163c67257b6c3f199dd9d1e0751f4c5b18
   category: notebooks
-  optional: true
-- name: libjpeg-turbo
-  version: 3.1.4.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.1.4.1-h84a0fba_0.conda
-  hash:
-    md5: b8a7544c83a67258b0e8592ec6a5d322
-    sha256: 17e035ae6a520ff6a6bb5dd93a4a7c3895891f4f9743bcb8c6ef607445a31cd0
-  category: container
   optional: true
 - name: libjpeg-turbo
   version: 3.1.4.1
@@ -21977,79 +17602,51 @@ package:
   category: notebooks
   optional: true
 - name: liblapack
-  version: 3.11.0
+  version: 3.9.0
   manager: conda
   platform: osx-64
   dependencies:
-    libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.11.0-8_ha7da5d7_accelerate.conda
+    libblas: 3.9.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-20_osx64_mkl.conda
   hash:
-    md5: 7f5c1cc676d89517962d8dc4d85d64cb
-    sha256: efb21fcf6d2dbbc3c4f55da4fb3a14530c56e3501675572e7d88949477111db3
+    md5: 58f08e12ad487fac4a08f90ff0b87aec
+    sha256: fdccac604746f9620fefaee313707aa2f500f73e51f8e3a4b690d5d4c90ce3dc
+  category: container
+  optional: true
+- name: liblapack
+  version: 3.9.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libblas: 3.9.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-20_osx64_mkl.conda
+  hash:
+    md5: 58f08e12ad487fac4a08f90ff0b87aec
+    sha256: fdccac604746f9620fefaee313707aa2f500f73e51f8e3a4b690d5d4c90ce3dc
+  category: notebooks
+  optional: true
+- name: liblapack
+  version: 3.11.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libblas: 3.11.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
+  hash:
+    md5: 85adeb3d469d082dbd9c8c39e36dec57
+    sha256: 8a076fe82142a00fe85f5a5a5351e286e8064f0100fe13608d19182cd0018c25
   category: container
   optional: true
 - name: liblapack
   version: 3.11.0
   manager: conda
-  platform: osx-64
-  dependencies:
-    libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.11.0-8_ha7da5d7_accelerate.conda
-  hash:
-    md5: 7f5c1cc676d89517962d8dc4d85d64cb
-    sha256: efb21fcf6d2dbbc3c4f55da4fb3a14530c56e3501675572e7d88949477111db3
-  category: notebooks
-  optional: true
-- name: liblapack
-  version: 3.11.0
-  manager: conda
   platform: osx-arm64
   dependencies:
     libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hcb0d94e_accelerate.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
   hash:
-    md5: 98058173a1b07c96fd2f0bb35e3dea5c
-    sha256: 622f6c759beb2eee046d2e6749c90440186299e72f2a1b5da0fcafd98add4c1d
-  category: container
-  optional: true
-- name: liblapack
-  version: 3.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hcb0d94e_accelerate.conda
-  hash:
-    md5: 98058173a1b07c96fd2f0bb35e3dea5c
-    sha256: 622f6c759beb2eee046d2e6749c90440186299e72f2a1b5da0fcafd98add4c1d
-  category: notebooks
-  optional: true
-- name: liblapacke
-  version: 3.11.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libblas: 3.11.0
-    libcblas: 3.11.0
-    liblapack: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblapacke-3.11.0-8_h7e64591_accelerate.conda
-  hash:
-    md5: 602a601604c737716ecbe590c023e0c5
-    sha256: 48555266f6270ef5fb074b9675937aef6dbc28bf69aa22bc81c73419a27da895
-  category: notebooks
-  optional: true
-- name: liblapacke
-  version: 3.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libblas: 3.11.0
-    libcblas: 3.11.0
-    liblapack: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.11.0-8_hbdd07e9_accelerate.conda
-  hash:
-    md5: 9e30190e30d9f81efe430b521cfb6202
-    sha256: cc5396c03800d35e531a3269a0f27cd27cf5333971ebf1b2f9df2de294b77f30
+    md5: 85adeb3d469d082dbd9c8c39e36dec57
+    sha256: 8a076fe82142a00fe85f5a5a5351e286e8064f0100fe13608d19182cd0018c25
   category: notebooks
   optional: true
 - name: liblzma
@@ -22159,7 +17756,7 @@ package:
     blosc: '>=1.21.6,<2.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     hdf4: '>=4.2.15,<4.2.16.0a0'
-    hdf5: '>=1.14.6,<1.14.7.0a0'
+    hdf5: '>=2.1.0,<3.0a0'
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.19.0,<9.0a0'
     libgcc: '>=14'
@@ -22170,10 +17767,10 @@ package:
     libzlib: '>=1.3.2,<2.0a0'
     openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-nompi_hb6f1874_104.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-nompi_h3c9b436_104.conda
   hash:
-    md5: e9e60f617e5545e1a7de60c2d01f8029
-    sha256: 7deab19f51934a5bfdf8eec10721d91a02c6a27632471527b07ece8f0d2c7a8e
+    md5: 6d38346d49e4638ec98649121d295d54
+    sha256: 6a1dbee34abe246c32abb89bd35855c25551de09562a719da97c4e5975f5f035
   category: notebooks
   optional: true
 - name: libnetcdf
@@ -22210,7 +17807,7 @@ package:
     blosc: '>=1.21.6,<2.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     hdf4: '>=4.2.15,<4.2.16.0a0'
-    hdf5: '>=1.14.6,<1.14.7.0a0'
+    hdf5: '>=2.1.0,<3.0a0'
     libaec: '>=1.1.5,<2.0a0'
     libcurl: '>=8.19.0,<9.0a0'
     libcxx: '>=19'
@@ -22220,10 +17817,10 @@ package:
     libzlib: '>=1.3.2,<2.0a0'
     openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.10.0-nompi_h2d2ed95_104.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.10.0-nompi_h7d224f4_104.conda
   hash:
-    md5: a58584c0f0e1caa07c02cf5ff065b03a
-    sha256: 8cecfe0abadb79ad1292213755962be0fc709da44ad0df59b9b052d2b82ace89
+    md5: af3769ed0f203a56e5775c113b446cd8
+    sha256: a44f7e91c740eac35e507eb8bb3b1b1edbf37eb498a2400b8165828175ca31fb
   category: notebooks
   optional: true
 - name: libnetcdf
@@ -22267,42 +17864,7 @@ package:
   hash:
     md5: 2a45e7f8af083626f009645a6481f12d
     sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
-  category: container
-  optional: true
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    c-ares: '>=1.34.6,<2.0a0'
-    libev: '>=4.33,<5.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
-  hash:
-    md5: 2a45e7f8af083626f009645a6481f12d
-    sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
   category: notebooks
-  optional: true
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    c-ares: '>=1.34.6,<2.0a0'
-    libev: '>=4.33,<5.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
-  hash:
-    md5: be5f0f007a4500a226ef001115535a3d
-    sha256: 13782715b9eeebc4ad16d36e84ca569d1495e3516aea3fe546a32caa0a597d82
-  category: container
   optional: true
 - name: libnghttp2
   version: 1.68.1
@@ -22336,41 +17898,7 @@ package:
   hash:
     md5: dba4c95e2fe24adcae4b77ebf33559ae
     sha256: 899551e16aac9dfb85bfc2fd98b655f4d1b7fea45720ec04ccb93d95b4d24798
-  category: container
-  optional: true
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.6,<2.0a0'
-    libcxx: '>=19'
-    libev: '>=4.33,<5.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h70048d4_0.conda
-  hash:
-    md5: dba4c95e2fe24adcae4b77ebf33559ae
-    sha256: 899551e16aac9dfb85bfc2fd98b655f4d1b7fea45720ec04ccb93d95b4d24798
   category: notebooks
-  optional: true
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.6,<2.0a0'
-    libcxx: '>=19'
-    libev: '>=4.33,<5.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
-  hash:
-    md5: 6ea18834adbc3b33df9bd9fb45eaf95b
-    sha256: 2bc7bc3978066f2c274ebcbf711850cc9ab92e023e433b9631958a098d11e10a
-  category: container
   optional: true
 - name: libnghttp2
   version: 1.68.1
@@ -22417,21 +17945,6 @@ package:
 - name: libopenblas
   version: 0.3.33
   manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
-  hash:
-    md5: 2d3278b721e40468295ca755c3b84070
-    sha256: 3d9aa85648e5e18a6d66db98b8c4317cc426721ad7a220aa86330d1ccedc8903
-  category: notebooks
-  optional: true
-- name: libopenblas
-  version: 0.3.33
-  manager: conda
   platform: linux-aarch64
   dependencies:
     _openmp_mutex: '>=4.5'
@@ -22461,401 +17974,35 @@ package:
     sha256: 723180af43679bcccd39ccea91a2c390834601a2ee338522c6b1d47b45d9db8d
   category: notebooks
   optional: true
-- name: libopentelemetry-cpp
-  version: 1.27.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libgrpc: '>=1.78.1,<1.79.0a0'
-    libopentelemetry-cpp-headers: 1.27.0
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    nlohmann_json: ''
-    prometheus-cpp: '>=1.3.0,<1.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.27.0-h9692893_0.conda
-  hash:
-    md5: 2a44700a9857b49a3fe72aca643d0921
-    sha256: 247b99f5dd32363d7231c9c5a6ad113e0b58ad3e85d68227999b5933d5005a6d
-  category: container
-  optional: true
-- name: libopentelemetry-cpp
-  version: 1.27.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libgrpc: '>=1.78.1,<1.79.0a0'
-    libopentelemetry-cpp-headers: 1.27.0
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    nlohmann_json: ''
-    prometheus-cpp: '>=1.3.0,<1.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.27.0-h9692893_0.conda
-  hash:
-    md5: 2a44700a9857b49a3fe72aca643d0921
-    sha256: 247b99f5dd32363d7231c9c5a6ad113e0b58ad3e85d68227999b5933d5005a6d
-  category: notebooks
-  optional: true
-- name: libopentelemetry-cpp
-  version: 1.27.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libgrpc: '>=1.78.1,<1.79.0a0'
-    libopentelemetry-cpp-headers: 1.27.0
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    nlohmann_json: ''
-    prometheus-cpp: '>=1.3.0,<1.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopentelemetry-cpp-1.27.0-hd82aec3_0.conda
-  hash:
-    md5: 6c1fc371b54221b0192bdabf4936afe7
-    sha256: 2987961441b545001ed848aeee1825dbce8ca1da9005c16ba65d13d7be88189b
-  category: container
-  optional: true
-- name: libopentelemetry-cpp
-  version: 1.27.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libgrpc: '>=1.78.1,<1.79.0a0'
-    libopentelemetry-cpp-headers: 1.27.0
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    nlohmann_json: ''
-    prometheus-cpp: '>=1.3.0,<1.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopentelemetry-cpp-1.27.0-hd82aec3_0.conda
-  hash:
-    md5: 6c1fc371b54221b0192bdabf4936afe7
-    sha256: 2987961441b545001ed848aeee1825dbce8ca1da9005c16ba65d13d7be88189b
-  category: notebooks
-  optional: true
-- name: libopentelemetry-cpp
-  version: 1.27.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libgrpc: '>=1.78.1,<1.79.0a0'
-    libopentelemetry-cpp-headers: 1.27.0
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    nlohmann_json: ''
-    prometheus-cpp: '>=1.3.0,<1.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopentelemetry-cpp-1.27.0-h7a0a166_0.conda
-  hash:
-    md5: 2b6d466bf0d5c0fba290e168eae7ac4a
-    sha256: 5ba2acb247c3f967c72391a912bcb4fd697de27c3e5033c6e5fa83797a4d14f2
-  category: container
-  optional: true
-- name: libopentelemetry-cpp
-  version: 1.27.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libgrpc: '>=1.78.1,<1.79.0a0'
-    libopentelemetry-cpp-headers: 1.27.0
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    nlohmann_json: ''
-    prometheus-cpp: '>=1.3.0,<1.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopentelemetry-cpp-1.27.0-h7a0a166_0.conda
-  hash:
-    md5: 2b6d466bf0d5c0fba290e168eae7ac4a
-    sha256: 5ba2acb247c3f967c72391a912bcb4fd697de27c3e5033c6e5fa83797a4d14f2
-  category: notebooks
-  optional: true
-- name: libopentelemetry-cpp
-  version: 1.27.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libgrpc: '>=1.78.1,<1.79.0a0'
-    libopentelemetry-cpp-headers: 1.27.0
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    nlohmann_json: ''
-    prometheus-cpp: '>=1.3.0,<1.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h08d5cc3_0.conda
-  hash:
-    md5: 35e93c8c0edb8dff7f9ebeb55ec4e6a6
-    sha256: db60a4d6eb5be208f8a0be686909b1f10635b3913a7c1ce391d4d26d991115c3
-  category: container
-  optional: true
-- name: libopentelemetry-cpp
-  version: 1.27.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcurl: '>=8.20.0,<9.0a0'
-    libgrpc: '>=1.78.1,<1.79.0a0'
-    libopentelemetry-cpp-headers: 1.27.0
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    nlohmann_json: ''
-    prometheus-cpp: '>=1.3.0,<1.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h08d5cc3_0.conda
-  hash:
-    md5: 35e93c8c0edb8dff7f9ebeb55ec4e6a6
-    sha256: db60a4d6eb5be208f8a0be686909b1f10635b3913a7c1ce391d4d26d991115c3
-  category: notebooks
-  optional: true
-- name: libopentelemetry-cpp-headers
-  version: 1.27.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_0.conda
-  hash:
-    md5: f8dcb0cff8f84f428bf76f1169bf50a7
-    sha256: 4a55bd84d166395a117592bb6139cf645eb402416987b856b41f96ba7b9d15d6
-  category: container
-  optional: true
-- name: libopentelemetry-cpp-headers
-  version: 1.27.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_0.conda
-  hash:
-    md5: f8dcb0cff8f84f428bf76f1169bf50a7
-    sha256: 4a55bd84d166395a117592bb6139cf645eb402416987b856b41f96ba7b9d15d6
-  category: notebooks
-  optional: true
-- name: libopentelemetry-cpp-headers
-  version: 1.27.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopentelemetry-cpp-headers-1.27.0-h8af1aa0_0.conda
-  hash:
-    md5: a3c6d10e216c51c477cd57353c9e36a6
-    sha256: 9daf4b34758a5ddb1e173aa738d4eedb48aa5aafb7d3628398b8e4fcea266f42
-  category: container
-  optional: true
-- name: libopentelemetry-cpp-headers
-  version: 1.27.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopentelemetry-cpp-headers-1.27.0-h8af1aa0_0.conda
-  hash:
-    md5: a3c6d10e216c51c477cd57353c9e36a6
-    sha256: 9daf4b34758a5ddb1e173aa738d4eedb48aa5aafb7d3628398b8e4fcea266f42
-  category: notebooks
-  optional: true
-- name: libopentelemetry-cpp-headers
-  version: 1.27.0
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopentelemetry-cpp-headers-1.27.0-h694c41f_0.conda
-  hash:
-    md5: 56d102b4190f3170dad25651544e6263
-    sha256: 887e0e2f9864b3a4f2565222a07d2d6544ce16f62b2a5637211d2e022dcdf777
-  category: container
-  optional: true
-- name: libopentelemetry-cpp-headers
-  version: 1.27.0
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopentelemetry-cpp-headers-1.27.0-h694c41f_0.conda
-  hash:
-    md5: 56d102b4190f3170dad25651544e6263
-    sha256: 887e0e2f9864b3a4f2565222a07d2d6544ce16f62b2a5637211d2e022dcdf777
-  category: notebooks
-  optional: true
-- name: libopentelemetry-cpp-headers
-  version: 1.27.0
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_0.conda
-  hash:
-    md5: f8039fbb88b31890de23c8a16ae03d92
-    sha256: 64724bf5c5c48ecbc92a7d561654c6305d6dc819e0773c8989877f0613e52542
-  category: container
-  optional: true
-- name: libopentelemetry-cpp-headers
-  version: 1.27.0
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_0.conda
-  hash:
-    md5: f8039fbb88b31890de23c8a16ae03d92
-    sha256: 64724bf5c5c48ecbc92a7d561654c6305d6dc819e0773c8989877f0613e52542
-  category: notebooks
-  optional: true
-- name: libparquet
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libarrow: 24.0.0
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libthrift: '>=0.22.0,<0.22.1.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-24.0.0-h7376487_7_cpu.conda
-  hash:
-    md5: a62bee3afc7722d5c2598b24b1d9cb62
-    sha256: 5d69cc37ef693176cc42e14bd9cab41001f7da1967d66b478fd4bfb8a9b84b3d
-  category: container
-  optional: true
-- name: libparquet
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libarrow: 24.0.0
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libthrift: '>=0.22.0,<0.22.1.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-24.0.0-h7376487_7_cpu.conda
-  hash:
-    md5: a62bee3afc7722d5c2598b24b1d9cb62
-    sha256: 5d69cc37ef693176cc42e14bd9cab41001f7da1967d66b478fd4bfb8a9b84b3d
-  category: notebooks
-  optional: true
-- name: libparquet
-  version: 24.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libarrow: 24.0.0
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libthrift: '>=0.22.0,<0.22.1.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_7_cpu.conda
-  hash:
-    md5: 133f78cd585aa523353d435fac030882
-    sha256: cce4e8ccef5f00febc3df67f7c8c4b144774d982893f3b874fb6f37e22c28185
-  category: container
-  optional: true
-- name: libparquet
-  version: 24.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libarrow: 24.0.0
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libthrift: '>=0.22.0,<0.22.1.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_7_cpu.conda
-  hash:
-    md5: 133f78cd585aa523353d435fac030882
-    sha256: cce4e8ccef5f00febc3df67f7c8c4b144774d982893f3b874fb6f37e22c28185
-  category: notebooks
-  optional: true
-- name: libparquet
-  version: 24.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libcxx: '>=21'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libthrift: '>=0.22.0,<0.22.1.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-24.0.0-h0f82bca_7_cpu.conda
-  hash:
-    md5: 8986eeddb6032853bdfb24eaf1171e4d
-    sha256: 7102d7ad47b55bd4ae4d8a611611e4f9aa5219929e5325f49cce4fe252db58f2
-  category: container
-  optional: true
-- name: libparquet
-  version: 24.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libcxx: '>=21'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libthrift: '>=0.22.0,<0.22.1.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-24.0.0-h0f82bca_7_cpu.conda
-  hash:
-    md5: 8986eeddb6032853bdfb24eaf1171e4d
-    sha256: 7102d7ad47b55bd4ae4d8a611611e4f9aa5219929e5325f49cce4fe252db58f2
-  category: notebooks
-  optional: true
-- name: libparquet
-  version: 24.0.0
+- name: libopenblas
+  version: 0.3.33
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libcxx: '>=21'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libthrift: '>=0.22.0,<0.22.1.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-24.0.0-h840b369_7_cpu.conda
+    libgfortran: ''
+    libgfortran5: '>=14.3.0'
+    llvm-openmp: '>=19.1.7'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
   hash:
-    md5: df79a126e560d6bba2f8711e0bac4cff
-    sha256: 9e0ca4e1e84a823ec2b85ae33028353ac8e0896ae98d4b48258eebc4926afa51
+    md5: 909e41855c29f0d52ae630198cd57135
+    sha256: 9dd455b2d172aeedfa2058d324b5b5822b0bc1b7c1f32cd183d7078540d2f6eb
   category: container
   optional: true
-- name: libparquet
-  version: 24.0.0
+- name: libopenblas
+  version: 0.3.33
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libarrow: 24.0.0
-    libcxx: '>=21'
-    libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libthrift: '>=0.22.0,<0.22.1.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-24.0.0-h840b369_7_cpu.conda
+    libgfortran: ''
+    libgfortran5: '>=14.3.0'
+    llvm-openmp: '>=19.1.7'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
   hash:
-    md5: df79a126e560d6bba2f8711e0bac4cff
-    sha256: 9e0ca4e1e84a823ec2b85ae33028353ac8e0896ae98d4b48258eebc4926afa51
+    md5: 909e41855c29f0d52ae630198cd57135
+    sha256: 9dd455b2d172aeedfa2058d324b5b5822b0bc1b7c1f32cd183d7078540d2f6eb
   category: notebooks
-  optional: true
-- name: libpng
-  version: 1.6.58
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
-  hash:
-    md5: eba48a68a1a2b9d3c0d9511548db85db
-    sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
-  category: container
   optional: true
 - name: libpng
   version: 1.6.58
@@ -22882,33 +18029,7 @@ package:
   hash:
     md5: f51503ac45a4888bce71af9027a2ecc9
     sha256: 483eaa53da40a6a3e558709d9f7b1ca388735364ae21a1ba58cf942514649c92
-  category: container
-  optional: true
-- name: libpng
-  version: 1.6.58
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
-  hash:
-    md5: f51503ac45a4888bce71af9027a2ecc9
-    sha256: 483eaa53da40a6a3e558709d9f7b1ca388735364ae21a1ba58cf942514649c92
   category: notebooks
-  optional: true
-- name: libpng
-  version: 1.6.58
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.58-he930e7c_0.conda
-  hash:
-    md5: 9744d43d5200f284260637304a069ddd
-    sha256: a669b22978e546484d18d99a210801b1823360a266d7035c713d8d1facd035f7
-  category: container
   optional: true
 - name: libpng
   version: 1.6.58
@@ -22934,97 +18055,38 @@ package:
   hash:
     md5: 2259ae0949dbe20c0665850365109b27
     sha256: 66eae34546df1f098a67064970c92aa14ae7a7505091889e00468294d2882c36
-  category: container
-  optional: true
-- name: libpng
-  version: 1.6.58
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
-  hash:
-    md5: 2259ae0949dbe20c0665850365109b27
-    sha256: 66eae34546df1f098a67064970c92aa14ae7a7505091889e00468294d2882c36
   category: notebooks
   optional: true
 - name: libprotobuf
-  version: 6.33.5
+  version: 7.35.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
+    libabseil: '>=20260526.0,<20260527.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h6eeba95_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-7.35.1-h3a69515_1.conda
   hash:
-    md5: 7a4b11f3dd7374f1991a4088390d07c1
-    sha256: a59aa3f076d5710c618ca8fd12d9cd8211d8b738f6b0e0c98517c0162f23a5de
-  category: container
-  optional: true
-- name: libprotobuf
-  version: 6.33.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h6eeba95_1.conda
-  hash:
-    md5: 7a4b11f3dd7374f1991a4088390d07c1
-    sha256: a59aa3f076d5710c618ca8fd12d9cd8211d8b738f6b0e0c98517c0162f23a5de
+    md5: c80393b49f041180405a587e5ac59b49
+    sha256: a14fc571ea573d733d2c18abb52123c09d56610dbf29d03cc85cf1470f5cc8ae
   category: notebooks
   optional: true
 - name: libprotobuf
-  version: 6.33.5
+  version: 7.35.1
   manager: conda
   platform: linux-aarch64
   dependencies:
-    libabseil: '>=20260107.1,<20260108.0a0'
+    libabseil: '>=20260526.0,<20260527.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.33.5-h306233d_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-7.35.1-h38371b1_1.conda
   hash:
-    md5: 97b7927d982dfc20f8f49ce5174d7466
-    sha256: 6a2ccd92be6a7e0256c6eeb2e61328a72d40004f08923733274ca2129dc7f70d
-  category: container
-  optional: true
-- name: libprotobuf
-  version: 6.33.5
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.33.5-h306233d_1.conda
-  hash:
-    md5: 97b7927d982dfc20f8f49ce5174d7466
-    sha256: 6a2ccd92be6a7e0256c6eeb2e61328a72d40004f08923733274ca2129dc7f70d
+    md5: 76593c5f1a65a923de490a5100a10df7
+    sha256: 19951d88c4e7ddd5b77036eb1343e396ce2a4160bb05db22f506a7fc1dae0e89
   category: notebooks
-  optional: true
-- name: libprotobuf
-  version: 6.33.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcxx: '>=19'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-6.33.5-hff14b61_1.conda
-  hash:
-    md5: 1450d8dbd5ac263d3d793fcf99612889
-    sha256: c511b4e8026c94b152031a9ee410583991b4a610ebbb1b86992724c37d9abf50
-  category: container
   optional: true
 - name: libprotobuf
   version: 6.33.5
@@ -23054,135 +18116,6 @@ package:
   hash:
     md5: 300fdae9d7ad150a90755f55b0a8a7a8
     sha256: 416c2244999d678dc9a4d8c3472336f8f754676125605399cf6e43956fa3d18b
-  category: container
-  optional: true
-- name: libprotobuf
-  version: 6.33.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.1,<20260108.0a0'
-    libcxx: '>=19'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h2d4b707_1.conda
-  hash:
-    md5: 300fdae9d7ad150a90755f55b0a8a7a8
-    sha256: 416c2244999d678dc9a4d8c3472336f8f754676125605399cf6e43956fa3d18b
-  category: notebooks
-  optional: true
-- name: libre2-11
-  version: 2025.11.05
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libabseil: '>=20260107.0,<20260108.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h0dc7533_1.conda
-  hash:
-    md5: ced7f10b6cfb4389385556f47c0ad949
-    sha256: 138fc85321a8c0731c1715688b38e2be4fb71db349c9ab25f685315095ae70ff
-  category: container
-  optional: true
-- name: libre2-11
-  version: 2025.11.05
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libabseil: '>=20260107.0,<20260108.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h0dc7533_1.conda
-  hash:
-    md5: ced7f10b6cfb4389385556f47c0ad949
-    sha256: 138fc85321a8c0731c1715688b38e2be4fb71db349c9ab25f685315095ae70ff
-  category: notebooks
-  optional: true
-- name: libre2-11
-  version: 2025.11.05
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libabseil: '>=20260107.0,<20260108.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libre2-11-2025.11.05-hc5e897d_1.conda
-  hash:
-    md5: 08f9cbede3e01bc1c51e4dd0267d585f
-    sha256: 74c0bfb8ac4d725584b45d0ea885bd3faa3b50f6cdfabef421e1b6c4c7844a7f
-  category: container
-  optional: true
-- name: libre2-11
-  version: 2025.11.05
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libabseil: '>=20260107.0,<20260108.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libre2-11-2025.11.05-hc5e897d_1.conda
-  hash:
-    md5: 08f9cbede3e01bc1c51e4dd0267d585f
-    sha256: 74c0bfb8ac4d725584b45d0ea885bd3faa3b50f6cdfabef421e1b6c4c7844a7f
-  category: notebooks
-  optional: true
-- name: libre2-11
-  version: 2025.11.05
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.0,<20260108.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2025.11.05-h6e8c311_1.conda
-  hash:
-    md5: 154f9f623c04dac40752d279bfdecebf
-    sha256: 092f1ed90ba105402b0868eda0a1a11fd1aedd93ea6bb7a57f6e2fc2218806d5
-  category: container
-  optional: true
-- name: libre2-11
-  version: 2025.11.05
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.0,<20260108.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2025.11.05-h6e8c311_1.conda
-  hash:
-    md5: 154f9f623c04dac40752d279bfdecebf
-    sha256: 092f1ed90ba105402b0868eda0a1a11fd1aedd93ea6bb7a57f6e2fc2218806d5
-  category: notebooks
-  optional: true
-- name: libre2-11
-  version: 2025.11.05
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.0,<20260108.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2025.11.05-h4c27e2a_1.conda
-  hash:
-    md5: 40d8ad21be4ccfff83a314076c3563f4
-    sha256: 1e2d23bbc1ffca54e4912365b7b59992b7ae5cbeb892779a6dcd9eca9f71c428
-  category: container
-  optional: true
-- name: libre2-11
-  version: 2025.11.05
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20260107.0,<20260108.0a0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2025.11.05-h4c27e2a_1.conda
-  hash:
-    md5: 40d8ad21be4ccfff83a314076c3563f4
-    sha256: 1e2d23bbc1ffca54e4912365b7b59992b7ae5cbeb892779a6dcd9eca9f71c428
   category: notebooks
   optional: true
 - name: librttopo
@@ -23497,10 +18430,10 @@ package:
     icu: '>=78.3,<79.0a0'
     libgcc: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-hf4e2dac_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-hf4e2dac_1.conda
   hash:
-    md5: 5474cc67600d752fc6e237d20bdb7e41
-    sha256: b9e6c2ffdc9f7a443879a9ebe74ce95a9f1c86336246b825261b1d7de4bc6213
+    md5: f283e98005089bf29ac5774c2e209fbf
+    sha256: f2ad4d3abd4ed7a6a0d28c0ff153e27cb45c406814faa2570bc2581804283674
   category: main
   optional: false
 - name: libsqlite
@@ -23508,12 +18441,13 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
+    icu: '>=78.3,<79.0a0'
     libgcc: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.2-h022381a_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.2-h10b116e_1.conda
   hash:
-    md5: 9b41221f50e108cacb8c382e1c668f27
-    sha256: e5d15d00dbe75b1a573a17beb72f15fc5a7b9329ae7a1aebb65115772f00800c
+    md5: 6d39fe0dc458643272905ecad03aaa77
+    sha256: 74abcfaa0f4c13024e07dbed75b378dd6e9ad4e6e2773ffe00993b0bf437ab58
   category: main
   optional: false
 - name: libsqlite
@@ -23523,10 +18457,10 @@ package:
   dependencies:
     __osx: '>=11.0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.2-h77d7759_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.2-h77d7759_1.conda
   hash:
-    md5: 78bad38060b6d8bd30e1f43474dcf77c
-    sha256: e092c945764c0194298af892bc79c89dbdacac7fab6fa0cd315f91deb0780c03
+    md5: 7dd6b4bcbd437bba3358914e8598ecc0
+    sha256: d6cced99517569e8a71bd5d90859343e18def7a1fb18e224671b54dfb531b387
   category: main
   optional: false
 - name: libsqlite
@@ -23535,11 +18469,12 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1b79a29_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_1.conda
   hash:
-    md5: 530ef68b7f9f7bee04f67db8d435f872
-    sha256: f06b6d9d50d5ad1bed09daada386eb1aa8ed7a9ca4618facd3aead75b82db9ff
+    md5: 2749be4dc52f3a6699e9dea29b78410a
+    sha256: f3b0289e03883f5ac3d646c318fefebc77f25897f2200459658f4273f901df45
   category: main
   optional: false
 - name: libssh2
@@ -23550,26 +18485,11 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.4.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
+    openssl: '>=3.5.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   hash:
-    md5: be2de152d8073ef1c01b7728475f2fe7
-    sha256: 0407ac9fda2bb67e11e357066eff144c845801d00b5f664efbc48813af1e7bb9
-  category: container
-  optional: true
-- name: libssh2
-  version: 1.11.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.4.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
-  hash:
-    md5: be2de152d8073ef1c01b7728475f2fe7
-    sha256: 0407ac9fda2bb67e11e357066eff144c845801d00b5f664efbc48813af1e7bb9
+    md5: eecce068c7e4eddeb169591baac20ac4
+    sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   category: notebooks
   optional: true
 - name: libssh2
@@ -23579,25 +18499,11 @@ package:
   dependencies:
     libgcc: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.4.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-ha41c0db_0.conda
+    openssl: '>=3.5.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
   hash:
-    md5: aeffe03c0e598f015aab08dbb04f6ee4
-    sha256: 40f2af5357457546bd11cd64a3b9043d83865180f65ce602515c35f353be35c7
-  category: container
-  optional: true
-- name: libssh2
-  version: 1.11.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=13'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.4.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-ha41c0db_0.conda
-  hash:
-    md5: aeffe03c0e598f015aab08dbb04f6ee4
-    sha256: 40f2af5357457546bd11cd64a3b9043d83865180f65ce602515c35f353be35c7
+    md5: eecc495bcfdd9da8058969656f916cc2
+    sha256: 1e289bcce4ee6a5817a19c66e296f3c644dcfa6e562e5c1cba807270798814e7
   category: notebooks
   optional: true
 - name: libssh2
@@ -23612,34 +18518,7 @@ package:
   hash:
     md5: a6cb15db1c2dc4d3a5f6cf3772e09e81
     sha256: 00654ba9e5f73aa1f75c1f69db34a19029e970a4aeb0fa8615934d8e9c369c3c
-  category: container
-  optional: true
-- name: libssh2
-  version: 1.11.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
-  hash:
-    md5: a6cb15db1c2dc4d3a5f6cf3772e09e81
-    sha256: 00654ba9e5f73aa1f75c1f69db34a19029e970a4aeb0fa8615934d8e9c369c3c
   category: notebooks
-  optional: true
-- name: libssh2
-  version: 1.11.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
-  hash:
-    md5: b68e8f66b94b44aaa8de4583d3d4cc40
-    sha256: 8bfe837221390ffc6f111ecca24fa12d4a6325da0c8d131333d63d6c37f27e0a
-  category: container
   optional: true
 - name: libssh2
   version: 1.11.1
@@ -23677,56 +18556,8 @@ package:
   hash:
     md5: 543fbc8d71f2a0baf04cf88ce96cb8bb
     sha256: 1dadc45e599f510dd5f97141dddcdbb9844d9f1430c1f3a38075cf1c58f87b4e
-  category: container
-  optional: true
-- name: libstdcxx
-  version: 15.2.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
-  hash:
-    md5: 543fbc8d71f2a0baf04cf88ce96cb8bb
-    sha256: 1dadc45e599f510dd5f97141dddcdbb9844d9f1430c1f3a38075cf1c58f87b4e
-  category: jupyter
-  optional: true
-- name: libstdcxx
-  version: 15.2.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
-  hash:
-    md5: 543fbc8d71f2a0baf04cf88ce96cb8bb
-    sha256: 1dadc45e599f510dd5f97141dddcdbb9844d9f1430c1f3a38075cf1c58f87b4e
-  category: notebooks
-  optional: true
-- name: libstdcxx
-  version: 15.2.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
-  hash:
-    md5: 543fbc8d71f2a0baf04cf88ce96cb8bb
-    sha256: 1dadc45e599f510dd5f97141dddcdbb9844d9f1430c1f3a38075cf1c58f87b4e
-  category: tools
-  optional: true
-- name: libstdcxx-ng
-  version: 15.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libstdcxx: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
-  hash:
-    md5: e5ce228e579726c07255dbf90dc62101
-    sha256: 0672b6b6e1791c92e8eccad58081a99d614fcf82bca5841f9dfa3c3e658f83b9
-  category: container
-  optional: true
+  category: main
+  optional: false
 - name: libstdcxx-ng
   version: 15.2.0
   manager: conda
@@ -23749,170 +18580,7 @@ package:
   hash:
     md5: c82ed61c3ec470c5ec624580e6ba16e4
     sha256: 56b5ec297a988961486694f1c598889c3a697d77a0b42b8cea3faaa12e9bd360
-  category: container
-  optional: true
-- name: libstdcxx-ng
-  version: 15.2.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libstdcxx: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_19.conda
-  hash:
-    md5: c82ed61c3ec470c5ec624580e6ba16e4
-    sha256: 56b5ec297a988961486694f1c598889c3a697d77a0b42b8cea3faaa12e9bd360
   category: notebooks
-  optional: true
-- name: libthrift
-  version: 0.22.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libevent: '>=2.1.12,<2.1.13.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
-  hash:
-    md5: b6e326fbe1e3948da50ec29cee0380db
-    sha256: af6025aa4a4fc3f4e71334000d2739d927e2f678607b109ec630cc17d716918a
-  category: container
-  optional: true
-- name: libthrift
-  version: 0.22.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libevent: '>=2.1.12,<2.1.13.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
-  hash:
-    md5: b6e326fbe1e3948da50ec29cee0380db
-    sha256: af6025aa4a4fc3f4e71334000d2739d927e2f678607b109ec630cc17d716918a
-  category: notebooks
-  optional: true
-- name: libthrift
-  version: 0.22.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libevent: '>=2.1.12,<2.1.13.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libthrift-0.22.0-ha522d1d_2.conda
-  hash:
-    md5: 6ecb1ee3cbccd5c3b9ba044e24515153
-    sha256: c43ccf2e53750a84962c2440359ec54fed01b36838d0a08e36f4b294c7d837a6
-  category: container
-  optional: true
-- name: libthrift
-  version: 0.22.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libevent: '>=2.1.12,<2.1.13.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libthrift-0.22.0-ha522d1d_2.conda
-  hash:
-    md5: 6ecb1ee3cbccd5c3b9ba044e24515153
-    sha256: c43ccf2e53750a84962c2440359ec54fed01b36838d0a08e36f4b294c7d837a6
-  category: notebooks
-  optional: true
-- name: libthrift
-  version: 0.22.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    libevent: '>=2.1.12,<2.1.13.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.22.0-hebea4ca_2.conda
-  hash:
-    md5: 36d5479e1b5967c2eb9824b953317e41
-    sha256: 89a20cb35e0f32d59a7080c934a56120591cb962d4fab1cba3a795a094bc8256
-  category: container
-  optional: true
-- name: libthrift
-  version: 0.22.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    libevent: '>=2.1.12,<2.1.13.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.22.0-hebea4ca_2.conda
-  hash:
-    md5: 36d5479e1b5967c2eb9824b953317e41
-    sha256: 89a20cb35e0f32d59a7080c934a56120591cb962d4fab1cba3a795a094bc8256
-  category: notebooks
-  optional: true
-- name: libthrift
-  version: 0.22.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    libevent: '>=2.1.12,<2.1.13.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.22.0-h1fb9c8a_2.conda
-  hash:
-    md5: d006875f9a58a44f92aec9a7ebeb7150
-    sha256: 568bb23db02b050c3903bec05edbcab84960c8c7e5a1710dac3109df997ac7f1
-  category: container
-  optional: true
-- name: libthrift
-  version: 0.22.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    libevent: '>=2.1.12,<2.1.13.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.22.0-h1fb9c8a_2.conda
-  hash:
-    md5: d006875f9a58a44f92aec9a7ebeb7150
-    sha256: 568bb23db02b050c3903bec05edbcab84960c8c7e5a1710dac3109df997ac7f1
-  category: notebooks
-  optional: true
-- name: libtiff
-  version: 4.7.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    lerc: '>=4.0.0,<5.0a0'
-    libdeflate: '>=1.25,<1.26.0a0'
-    libgcc: '>=14'
-    libjpeg-turbo: '>=3.1.0,<4.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libstdcxx: '>=14'
-    libwebp-base: '>=1.6.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-  hash:
-    md5: cd5a90476766d53e901500df9215e927
-    sha256: e5f8c38625aa6d567809733ae04bb71c161a42e44a9fa8227abe61fa5c60ebe0
-  category: container
   optional: true
 - name: libtiff
   version: 4.7.1
@@ -23953,26 +18621,6 @@ package:
   hash:
     md5: 8c6fd84f9c87ac00636007c6131e457d
     sha256: 7ff79470db39e803e21b8185bc8f19c460666d5557b1378d1b1e857d929c6b39
-  category: container
-  optional: true
-- name: libtiff
-  version: 4.7.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    lerc: '>=4.0.0,<5.0a0'
-    libdeflate: '>=1.25,<1.26.0a0'
-    libgcc: '>=14'
-    libjpeg-turbo: '>=3.1.0,<4.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libstdcxx: '>=14'
-    libwebp-base: '>=1.6.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.1-hdb009f0_1.conda
-  hash:
-    md5: 8c6fd84f9c87ac00636007c6131e457d
-    sha256: 7ff79470db39e803e21b8185bc8f19c460666d5557b1378d1b1e857d929c6b39
   category: notebooks
   optional: true
 - name: libtiff
@@ -23993,47 +18641,7 @@ package:
   hash:
     md5: 9d4344f94de4ab1330cdc41c40152ea6
     sha256: e53424c34147301beae2cd9223ebf593720d94c038b3f03cacd0535e12c9668e
-  category: container
-  optional: true
-- name: libtiff
-  version: 4.7.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    lerc: '>=4.0.0,<5.0a0'
-    libcxx: '>=19'
-    libdeflate: '>=1.25,<1.26.0a0'
-    libjpeg-turbo: '>=3.1.0,<4.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libwebp-base: '>=1.6.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.1-ha0a348c_1.conda
-  hash:
-    md5: 9d4344f94de4ab1330cdc41c40152ea6
-    sha256: e53424c34147301beae2cd9223ebf593720d94c038b3f03cacd0535e12c9668e
   category: notebooks
-  optional: true
-- name: libtiff
-  version: 4.7.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    lerc: '>=4.0.0,<5.0a0'
-    libcxx: '>=19'
-    libdeflate: '>=1.25,<1.26.0a0'
-    libjpeg-turbo: '>=3.1.0,<4.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libwebp-base: '>=1.6.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.1-h4030677_1.conda
-  hash:
-    md5: e2a72ab2fa54ecb6abab2b26cde93500
-    sha256: e9248077b3fa63db94caca42c8dbc6949c6f32f94d1cafad127f9005d9b1507f
-  category: container
   optional: true
 - name: libtiff
   version: 4.7.1
@@ -24056,56 +18664,56 @@ package:
   category: notebooks
   optional: true
 - name: libtorch
-  version: 2.12.0
+  version: 2.12.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
     fmt: '>=12.1.0,<12.2.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
+    libabseil: '>=20260526.0,<20260527.0a0'
     libblas: '*'
     libcblas: '>=3.11.0,<4.0a0'
     libgcc: '>=14'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
+    libprotobuf: '>=7.35.1,<7.35.2.0a0'
     libstdcxx: '>=14'
     libuv: '>=1.52.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    llvm-openmp: '>=22.1.7'
+    llvm-openmp: '>=22.1.8'
     mkl: '>=2026.0.0,<2027.0a0'
     onednn: '>=3.12,<4.0a0'
     pybind11-abi: '11'
     sleef: '>=3.9.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.12.0-cpu_mkl_h55d9b97_100.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.12.1-cpu_mkl_h4f7e408_100.conda
   hash:
-    md5: 77ced7a1eb9aaf007549855ec2c4f91d
-    sha256: fc1f45a1ff74d1e3436c2b4de4d9a1b1aadae68d62b22befa3d2750c12db450d
+    md5: 00e6cb69159e94d2fc13848ce4453e7e
+    sha256: 7e3c58fffa49da11b2dd388b0031d7d28632b36591d658881bedf57c69ac93d8
   category: notebooks
   optional: true
 - name: libtorch
-  version: 2.12.0
+  version: 2.12.1
   manager: conda
   platform: linux-aarch64
   dependencies:
     _openmp_mutex: '>=4.5'
     fmt: '>=12.1.0,<12.2.0a0'
-    libabseil: '>=20260107.1,<20260108.0a0'
+    libabseil: '>=20260526.0,<20260527.0a0'
     libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
-    libgcc: '>=13'
+    libgcc: '>=14'
     liblapack: '>=3.9.0,<4.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=13'
+    libprotobuf: '>=7.35.1,<7.35.2.0a0'
+    libstdcxx: '>=14'
     libuv: '>=1.52.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    llvm-openmp: '>=22.1.7'
+    llvm-openmp: '>=22.1.8'
     onednn: '>=3.12,<4.0a0'
     pybind11-abi: '11'
     sleef: '>=3.9.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libtorch-2.12.0-cpu_generic_h4236a28_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libtorch-2.12.1-cpu_generic_hb12a5ee_0.conda
   hash:
-    md5: 3269933e9b4abc60fa80d18d43464e2a
-    sha256: 69cc7b44fdd12101e2a36a293c27bb755d079f186b966bb47ef0bfc0b4bb062c
+    md5: c79c0f29047c71cb69cb43a8074b66cd
+    sha256: 39c971c0993784e217d43d987cb5f797e03a41e249505e1e5771fba1fdf01c0a
   category: notebooks
   optional: true
 - name: libtorch
@@ -24116,21 +18724,21 @@ package:
     __osx: '>=11.0'
     fmt: '>=12.1.0,<12.2.0a0'
     libabseil: '>=20260107.1,<20260108.0a0'
-    libblas: '>=3.9.0,<4.0a0'
+    libblas: '*'
     libcblas: '>=3.9.0,<4.0a0'
     libcxx: '>=19'
-    liblapack: '>=3.9.0,<4.0a0'
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
     libuv: '>=1.52.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     llvm-openmp: '>=19.1.7'
+    mkl: '>=2023.2.0,<2024.0a0'
     onednn: '>=3.12,<4.0a0'
     pybind11-abi: '11'
     sleef: '>=3.9.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libtorch-2.12.0-cpu_generic_hb7e9ad9_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libtorch-2.12.0-cpu_mkl_hf457987_100.conda
   hash:
-    md5: 8f3144e85b00ccd803eb5687fb699b55
-    sha256: ed20035c11c2e743f9bb7bf038022b32ee4fe57ea83c6b0eea0f470d268223c0
+    md5: c7e2e72a741d315de4dc0525ddce4b58
+    sha256: 9191a58a513b8f743c6e48f60eaa9e1a749e4b935c268c490f8431ee6598f1e5
   category: notebooks
   optional: true
 - name: libtorch
@@ -24156,104 +18764,6 @@ package:
   hash:
     md5: 24a9f36e4520d28fa2db397555394709
     sha256: 116bd357ac03d3b77b9e60883fddfcdc4f2ca7fe65dfb007f2e0856d1297eee0
-  category: notebooks
-  optional: true
-- name: libutf8proc
-  version: 2.11.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
-  hash:
-    md5: 1247168fe4a0b8912e3336bccdbf98a5
-    sha256: ecbf4b7520296ed580498dc66a72508b8a79da5126e1d6dc650a7087171288f9
-  category: container
-  optional: true
-- name: libutf8proc
-  version: 2.11.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
-  hash:
-    md5: 1247168fe4a0b8912e3336bccdbf98a5
-    sha256: ecbf4b7520296ed580498dc66a72508b8a79da5126e1d6dc650a7087171288f9
-  category: notebooks
-  optional: true
-- name: libutf8proc
-  version: 2.11.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libutf8proc-2.11.3-hec6f9f7_0.conda
-  hash:
-    md5: afc02d5958046be06b176058e9d630d7
-    sha256: a67e1c2355f98befb280bc91990504500ba28a82d5441c9fb9e10015abfd3b14
-  category: container
-  optional: true
-- name: libutf8proc
-  version: 2.11.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libutf8proc-2.11.3-hec6f9f7_0.conda
-  hash:
-    md5: afc02d5958046be06b176058e9d630d7
-    sha256: a67e1c2355f98befb280bc91990504500ba28a82d5441c9fb9e10015abfd3b14
-  category: notebooks
-  optional: true
-- name: libutf8proc
-  version: 2.11.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.11.3-hc282952_0.conda
-  hash:
-    md5: 2c49b6f6ec9a510bbb75ecbd2a572697
-    sha256: 626db214208e8da6aa9a904518a0442e5bff7b4602cc295dd5ce1f4a98844c1d
-  category: container
-  optional: true
-- name: libutf8proc
-  version: 2.11.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.11.3-hc282952_0.conda
-  hash:
-    md5: 2c49b6f6ec9a510bbb75ecbd2a572697
-    sha256: 626db214208e8da6aa9a904518a0442e5bff7b4602cc295dd5ce1f4a98844c1d
-  category: notebooks
-  optional: true
-- name: libutf8proc
-  version: 2.11.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.11.3-h2431656_0.conda
-  hash:
-    md5: 2255add2f6ae77d0a96624a5cbde6d45
-    sha256: ae1a82e62cd4e3c18e005ae7ff4358ed72b2bfbfe990d5a6a5587f81e9a100dc
-  category: container
-  optional: true
-- name: libutf8proc
-  version: 2.11.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.11.3-h2431656_0.conda
-  hash:
-    md5: 2255add2f6ae77d0a96624a5cbde6d45
-    sha256: ae1a82e62cd4e3c18e005ae7ff4358ed72b2bfbfe990d5a6a5587f81e9a100dc
   category: notebooks
   optional: true
 - name: libuuid
@@ -24390,32 +18900,7 @@ package:
   hash:
     md5: aea31d2e5b1091feca96fcfe945c3cf9
     sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
-  category: container
-  optional: true
-- name: libwebp-base
-  version: 1.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
-  hash:
-    md5: aea31d2e5b1091feca96fcfe945c3cf9
-    sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
   category: notebooks
-  optional: true
-- name: libwebp-base
-  version: 1.6.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
-  hash:
-    md5: 24e92d0942c799db387f5c9d7b81f1af
-    sha256: b03700a1f741554e8e5712f9b06dd67e76f5301292958cd3cb1ac8c6fdd9ed25
-  category: container
   optional: true
 - name: libwebp-base
   version: 1.6.0
@@ -24439,18 +18924,6 @@ package:
   hash:
     md5: 7bb6608cf1f83578587297a158a6630b
     sha256: 00dbfe574b5d9b9b2b519acb07545380a6bc98d1f76a02695be4995d4ec91391
-  category: container
-  optional: true
-- name: libwebp-base
-  version: 1.6.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.6.0-hb807250_0.conda
-  hash:
-    md5: 7bb6608cf1f83578587297a158a6630b
-    sha256: 00dbfe574b5d9b9b2b519acb07545380a6bc98d1f76a02695be4995d4ec91391
   category: notebooks
   optional: true
 - name: libwebp-base
@@ -24463,140 +18936,6 @@ package:
   hash:
     md5: e5e7d467f80da752be17796b87fe6385
     sha256: a4de3f371bb7ada325e1f27a4ef7bcc81b2b6a330e46fac9c2f78ac0755ea3dd
-  category: container
-  optional: true
-- name: libwebp-base
-  version: 1.6.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.6.0-h07db88b_0.conda
-  hash:
-    md5: e5e7d467f80da752be17796b87fe6385
-    sha256: a4de3f371bb7ada325e1f27a4ef7bcc81b2b6a330e46fac9c2f78ac0755ea3dd
-  category: notebooks
-  optional: true
-- name: libxcb
-  version: 1.17.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    pthread-stubs: ''
-    xorg-libxau: '>=1.0.11,<2.0a0'
-    xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
-  hash:
-    md5: 92ed62436b625154323d40d5f2f11dd7
-    sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
-  category: container
-  optional: true
-- name: libxcb
-  version: 1.17.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    pthread-stubs: ''
-    xorg-libxau: '>=1.0.11,<2.0a0'
-    xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
-  hash:
-    md5: 92ed62436b625154323d40d5f2f11dd7
-    sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
-  category: notebooks
-  optional: true
-- name: libxcb
-  version: 1.17.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=13'
-    pthread-stubs: ''
-    xorg-libxau: '>=1.0.11,<2.0a0'
-    xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
-  hash:
-    md5: cd14ee5cca2464a425b1dbfc24d90db2
-    sha256: 461cab3d5650ac6db73a367de5c8eca50363966e862dcf60181d693236b1ae7b
-  category: container
-  optional: true
-- name: libxcb
-  version: 1.17.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=13'
-    pthread-stubs: ''
-    xorg-libxau: '>=1.0.11,<2.0a0'
-    xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
-  hash:
-    md5: cd14ee5cca2464a425b1dbfc24d90db2
-    sha256: 461cab3d5650ac6db73a367de5c8eca50363966e862dcf60181d693236b1ae7b
-  category: notebooks
-  optional: true
-- name: libxcb
-  version: 1.17.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    pthread-stubs: ''
-    xorg-libxau: '>=1.0.11,<2.0a0'
-    xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
-  hash:
-    md5: bbeca862892e2898bdb45792a61c4afc
-    sha256: 8896cd5deff6f57d102734f3e672bc17120613647288f9122bec69098e839af7
-  category: container
-  optional: true
-- name: libxcb
-  version: 1.17.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    pthread-stubs: ''
-    xorg-libxau: '>=1.0.11,<2.0a0'
-    xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
-  hash:
-    md5: bbeca862892e2898bdb45792a61c4afc
-    sha256: 8896cd5deff6f57d102734f3e672bc17120613647288f9122bec69098e839af7
-  category: notebooks
-  optional: true
-- name: libxcb
-  version: 1.17.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    pthread-stubs: ''
-    xorg-libxau: '>=1.0.11,<2.0a0'
-    xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
-  hash:
-    md5: af523aae2eca6dfa1c8eec693f5b9a79
-    sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
-  category: container
-  optional: true
-- name: libxcb
-  version: 1.17.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    pthread-stubs: ''
-    xorg-libxau: '>=1.0.11,<2.0a0'
-    xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
-  hash:
-    md5: af523aae2eca6dfa1c8eec693f5b9a79
-    sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
   category: notebooks
   optional: true
 - name: libxml2
@@ -24634,23 +18973,6 @@ package:
     md5: 995d8c8bad2a3cc8db14675a153dec2b
     sha256: 3bc5551720c58591f6ea1146f7d1539c734ed1c40e7b9f5cb8cb7e900c509aba
   category: notebooks
-  optional: true
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=14'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.3-h869d058_0.conda
-  hash:
-    md5: 2cffef27cb2eb9ed1e315a1e269d4335
-    sha256: e3af6af9df73bd3c7a8e4e6c8cc38df3699e7f588b0705c257a8601e40acfbdf
-  category: container
   optional: true
 - name: libxml2
   version: 2.15.3
@@ -24718,23 +19040,6 @@ package:
   hash:
     md5: 8e037d73747d6fe34e12d7bcac10cf21
     sha256: 2fe1d8de0854342ae9cabe408b476935f82f5636e153b3b497456264dc8ff3a1
-  category: container
-  optional: true
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_0.conda
-  hash:
-    md5: 8e037d73747d6fe34e12d7bcac10cf21
-    sha256: 2fe1d8de0854342ae9cabe408b476935f82f5636e153b3b497456264dc8ff3a1
   category: notebooks
   optional: true
 - name: libxml2-16
@@ -24785,22 +19090,6 @@ package:
   hash:
     md5: 68866231cfe8789e780347f2482df96d
     sha256: ad048a9ca1bf2cdfedb2b0c231050da416c44ee1436a3d1a83b51d2e2deaa842
-  category: container
-  optional: true
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=14'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-16-2.15.3-h79dcc73_0.conda
-  hash:
-    md5: 68866231cfe8789e780347f2482df96d
-    sha256: ad048a9ca1bf2cdfedb2b0c231050da416c44ee1436a3d1a83b51d2e2deaa842
   category: notebooks
   optional: true
 - name: libxml2-16
@@ -24834,22 +19123,6 @@ package:
     md5: c74ae93cd7876e3a9c4b5569d5e29e34
     sha256: 437f003e299d77403db42d17e532d686236f357ac5c3d6bf466558c697902597
   category: notebooks
-  optional: true
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_0.conda
-  hash:
-    md5: 19edaa53885fc8205614b03da2482282
-    sha256: ff75b84cdb9e8d123db2fa694a8ac2c2059516b6cbc98ac21fb68e235d0fd354
-  category: container
   optional: true
 - name: libxml2-16
   version: 2.15.3
@@ -25188,238 +19461,6 @@ package:
     sha256: a092b6d86ee2ec3af1fdecf4835438eadefe3e4e59e77019848a669f8a60de94
   category: notebooks
   optional: true
-- name: locket
-  version: 1.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
-  url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 91e27ef3d05cc772ce627e51cff111c4
-    sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
-  category: container
-  optional: true
-- name: locket
-  version: 1.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
-  url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 91e27ef3d05cc772ce627e51cff111c4
-    sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
-  category: notebooks
-  optional: true
-- name: locket
-  version: 1.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
-  url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 91e27ef3d05cc772ce627e51cff111c4
-    sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
-  category: container
-  optional: true
-- name: locket
-  version: 1.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
-  url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 91e27ef3d05cc772ce627e51cff111c4
-    sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
-  category: notebooks
-  optional: true
-- name: locket
-  version: 1.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
-  url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 91e27ef3d05cc772ce627e51cff111c4
-    sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
-  category: container
-  optional: true
-- name: locket
-  version: 1.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
-  url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 91e27ef3d05cc772ce627e51cff111c4
-    sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
-  category: notebooks
-  optional: true
-- name: locket
-  version: 1.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
-  url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 91e27ef3d05cc772ce627e51cff111c4
-    sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
-  category: container
-  optional: true
-- name: locket
-  version: 1.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
-  url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 91e27ef3d05cc772ce627e51cff111c4
-    sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
-  category: notebooks
-  optional: true
-- name: lz4
-  version: 4.4.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    python: ''
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.4.5-py313h28739b2_1.conda
-  hash:
-    md5: e69ad33075938ba81e43311da86b809c
-    sha256: cbc82f4fa7587376c038d2f0471a73efa7ade4439857b04a0cc839262f1de6e5
-  category: container
-  optional: true
-- name: lz4
-  version: 4.4.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    python: ''
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.4.5-py313h28739b2_1.conda
-  hash:
-    md5: e69ad33075938ba81e43311da86b809c
-    sha256: cbc82f4fa7587376c038d2f0471a73efa7ade4439857b04a0cc839262f1de6e5
-  category: notebooks
-  optional: true
-- name: lz4
-  version: 4.4.5
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    python: 3.13.*
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-4.4.5-py313h2c0738f_1.conda
-  hash:
-    md5: 33766682da44bee1aeb2935b56de834c
-    sha256: 22e8afddb914e3f751671ffb6e7c847ede4eb634e6f35aeee53389adcd2edcec
-  category: container
-  optional: true
-- name: lz4
-  version: 4.4.5
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    python: 3.13.*
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-4.4.5-py313h2c0738f_1.conda
-  hash:
-    md5: 33766682da44bee1aeb2935b56de834c
-    sha256: 22e8afddb914e3f751671ffb6e7c847ede4eb634e6f35aeee53389adcd2edcec
-  category: notebooks
-  optional: true
-- name: lz4
-  version: 4.4.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    python: ''
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.4.5-py313hab77a93_1.conda
-  hash:
-    md5: 6838efa78f5071775a7766062cfc85d2
-    sha256: a35f5d5225d4c6dd13e229881d3013e18f0e3a372bb6e3d9bf299fc832309143
-  category: container
-  optional: true
-- name: lz4
-  version: 4.4.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    python: ''
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.4.5-py313hab77a93_1.conda
-  hash:
-    md5: 6838efa78f5071775a7766062cfc85d2
-    sha256: a35f5d5225d4c6dd13e229881d3013e18f0e3a372bb6e3d9bf299fc832309143
-  category: notebooks
-  optional: true
-- name: lz4
-  version: 4.4.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    python: 3.13.*
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.4.5-py313hd065f0a_1.conda
-  hash:
-    md5: ece4dab2afb98b065b69ce769a5c6c42
-    sha256: 71dfac3971dcd134c8a31b3f670d00b8d551e275fb386568ec11ab68d95fe540
-  category: container
-  optional: true
-- name: lz4
-  version: 4.4.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    python: 3.13.*
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.4.5-py313hd065f0a_1.conda
-  hash:
-    md5: ece4dab2afb98b065b69ce769a5c6c42
-    sha256: 71dfac3971dcd134c8a31b3f670d00b8d551e275fb386568ec11ab68d95fe540
-  category: notebooks
-  optional: true
-- name: lz4-c
-  version: 1.10.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
-  hash:
-    md5: 9de5350a85c4a20c685259b889aa6393
-    sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346
-  category: container
-  optional: true
 - name: lz4-c
   version: 1.10.0
   manager: conda
@@ -25445,19 +19486,6 @@ package:
   hash:
     md5: 6654e411da94011e8fbe004eacb8fe11
     sha256: 67e55058d275beea76c1882399640c37b5be8be4eb39354c94b610928e9a0573
-  category: container
-  optional: true
-- name: lz4-c
-  version: 1.10.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
-  hash:
-    md5: 6654e411da94011e8fbe004eacb8fe11
-    sha256: 67e55058d275beea76c1882399640c37b5be8be4eb39354c94b610928e9a0573
   category: notebooks
   optional: true
 - name: lz4-c
@@ -25471,33 +19499,7 @@ package:
   hash:
     md5: d6b9bd7e356abd7e3a633d59b753495a
     sha256: 8da3c9d4b596e481750440c0250a7e18521e7f69a47e1c8415d568c847c08a1c
-  category: container
-  optional: true
-- name: lz4-c
-  version: 1.10.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=18'
-  url: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.10.0-h240833e_1.conda
-  hash:
-    md5: d6b9bd7e356abd7e3a633d59b753495a
-    sha256: 8da3c9d4b596e481750440c0250a7e18521e7f69a47e1c8415d568c847c08a1c
   category: notebooks
-  optional: true
-- name: lz4-c
-  version: 1.10.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=18'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
-  hash:
-    md5: 01511afc6cc1909c5303cf31be17b44f
-    sha256: 94d3e2a485dab8bdfdd4837880bde3dd0d701e2b97d6134b8806b7c8e69c8652
-  category: container
   optional: true
 - name: lz4-c
   version: 1.10.0
@@ -25582,7 +19584,7 @@ package:
   dependencies:
     importlib-metadata: ''
     markupsafe: '>=0.9.2'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.12-pyhcf101f3_0.conda
   hash:
     md5: a73036dabdd6dfe9679ed893baa8b230
@@ -25596,7 +19598,7 @@ package:
   dependencies:
     importlib-metadata: ''
     markupsafe: '>=0.9.2'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.12-pyhcf101f3_0.conda
   hash:
     md5: a73036dabdd6dfe9679ed893baa8b230
@@ -25610,7 +19612,7 @@ package:
   dependencies:
     importlib-metadata: ''
     markupsafe: '>=0.9.2'
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.12-pyhcf101f3_0.conda
   hash:
     md5: a73036dabdd6dfe9679ed893baa8b230
@@ -26131,107 +20133,107 @@ package:
   category: notebooks
   optional: true
 - name: mistune
-  version: 3.3.1
+  version: 3.3.2
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
   hash:
-    md5: 1fe73f1762c2114c946cf2e7f074cc43
-    sha256: 240fbb25ca907465df57fe5ba2b040fc868fa88dfa7da42741b3b8bd092b4f17
+    md5: e92e7aa653b4c71d0cd3cd39eadc302f
+    sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
   category: container
   optional: true
 - name: mistune
-  version: 3.3.1
+  version: 3.3.2
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
   hash:
-    md5: 1fe73f1762c2114c946cf2e7f074cc43
-    sha256: 240fbb25ca907465df57fe5ba2b040fc868fa88dfa7da42741b3b8bd092b4f17
+    md5: e92e7aa653b4c71d0cd3cd39eadc302f
+    sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
   category: jupyter
   optional: true
 - name: mistune
-  version: 3.3.1
+  version: 3.3.2
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
   hash:
-    md5: 1fe73f1762c2114c946cf2e7f074cc43
-    sha256: 240fbb25ca907465df57fe5ba2b040fc868fa88dfa7da42741b3b8bd092b4f17
+    md5: e92e7aa653b4c71d0cd3cd39eadc302f
+    sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
   category: container
   optional: true
 - name: mistune
-  version: 3.3.1
+  version: 3.3.2
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
   hash:
-    md5: 1fe73f1762c2114c946cf2e7f074cc43
-    sha256: 240fbb25ca907465df57fe5ba2b040fc868fa88dfa7da42741b3b8bd092b4f17
+    md5: e92e7aa653b4c71d0cd3cd39eadc302f
+    sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
   category: jupyter
   optional: true
 - name: mistune
-  version: 3.3.1
+  version: 3.3.2
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
   hash:
-    md5: 1fe73f1762c2114c946cf2e7f074cc43
-    sha256: 240fbb25ca907465df57fe5ba2b040fc868fa88dfa7da42741b3b8bd092b4f17
+    md5: e92e7aa653b4c71d0cd3cd39eadc302f
+    sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
   category: container
   optional: true
 - name: mistune
-  version: 3.3.1
+  version: 3.3.2
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
   hash:
-    md5: 1fe73f1762c2114c946cf2e7f074cc43
-    sha256: 240fbb25ca907465df57fe5ba2b040fc868fa88dfa7da42741b3b8bd092b4f17
+    md5: e92e7aa653b4c71d0cd3cd39eadc302f
+    sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
   category: jupyter
   optional: true
 - name: mistune
-  version: 3.3.1
+  version: 3.3.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
   hash:
-    md5: 1fe73f1762c2114c946cf2e7f074cc43
-    sha256: 240fbb25ca907465df57fe5ba2b040fc868fa88dfa7da42741b3b8bd092b4f17
+    md5: e92e7aa653b4c71d0cd3cd39eadc302f
+    sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
   category: container
   optional: true
 - name: mistune
-  version: 3.3.1
+  version: 3.3.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
   hash:
-    md5: 1fe73f1762c2114c946cf2e7f074cc43
-    sha256: 240fbb25ca907465df57fe5ba2b040fc868fa88dfa7da42741b3b8bd092b4f17
+    md5: e92e7aa653b4c71d0cd3cd39eadc302f
+    sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
   category: jupyter
   optional: true
 - name: mkl
@@ -26270,6 +20272,32 @@ package:
     sha256: 740a02cf7b3c0d6dd47dbb4d2e222ed23d326971fe608d737614db1033bd107d
   category: notebooks
   optional: true
+- name: mkl
+  version: 2023.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    _openmp_mutex: '>=4.5'
+    tbb: 2021.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/mkl-2023.2.0-h694c41f_50502.conda
+  hash:
+    md5: 0bdfc939c8542e0bc6041cbd9a900219
+    sha256: 1841842ed23ddd61fd46b2282294b1b9ef332f39229645e1331739ee8c2a6136
+  category: container
+  optional: true
+- name: mkl
+  version: 2023.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    _openmp_mutex: '>=4.5'
+    tbb: 2021.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/mkl-2023.2.0-h694c41f_50502.conda
+  hash:
+    md5: 0bdfc939c8542e0bc6041cbd9a900219
+    sha256: 1841842ed23ddd61fd46b2282294b1b9ef332f39229645e1331739ee8c2a6136
+  category: notebooks
+  optional: true
 - name: more-itertools
   version: 11.1.0
   manager: conda
@@ -26287,7 +20315,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.1.0-pyhcf101f3_0.conda
   hash:
     md5: 0e694257dbf916540b749c3ffc808efe
@@ -26299,7 +20327,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.1.0-pyhcf101f3_0.conda
   hash:
     md5: 0e694257dbf916540b749c3ffc808efe
@@ -26311,7 +20339,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.1.0-pyhcf101f3_0.conda
   hash:
     md5: 0e694257dbf916540b749c3ffc808efe
@@ -26484,44 +20512,12 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    python: '>=3.13,<3.14.0a0'
+    python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.2.1-py313h7037e92_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.2.1-py313hc8edb43_1.conda
   hash:
-    md5: 4f7f0bbf165e65d6f620251860c098c2
-    sha256: 87a569daa29cb526cff5e9e5cca3fc92c479a92f13c0bac6a4ad6b38ef068f5b
-  category: container
-  optional: true
-- name: msgpack-python
-  version: 1.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.2.1-py313h7037e92_0.conda
-  hash:
-    md5: 4f7f0bbf165e65d6f620251860c098c2
-    sha256: 87a569daa29cb526cff5e9e5cca3fc92c479a92f13c0bac6a4ad6b38ef068f5b
-  category: notebooks
-  optional: true
-- name: msgpack-python
-  version: 1.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.2.1-py313h7037e92_0.conda
-  hash:
-    md5: 4f7f0bbf165e65d6f620251860c098c2
-    sha256: 87a569daa29cb526cff5e9e5cca3fc92c479a92f13c0bac6a4ad6b38ef068f5b
+    md5: edd7c461f72756bd3829f836e107c488
+    sha256: 6bc2690c67ba7354affa0498a68998fad8f66759c287706e7ff42c2242e14ccb
   category: tools
   optional: true
 - name: msgpack-python
@@ -26531,42 +20527,12 @@ package:
   dependencies:
     libgcc: '>=14'
     libstdcxx: '>=14'
-    python: '>=3.13,<3.14.0a0'
+    python: 3.13.*
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/msgpack-python-1.2.1-py313he6111f0_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/msgpack-python-1.2.1-py313h75bc965_1.conda
   hash:
-    md5: 6c8e30755c2e19db1628581d5587a0a8
-    sha256: 7d976f5702ad078abfd6d2f3e266a64f2736f7906f55676fa97a25ce2911a2f3
-  category: container
-  optional: true
-- name: msgpack-python
-  version: 1.2.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/msgpack-python-1.2.1-py313he6111f0_0.conda
-  hash:
-    md5: 6c8e30755c2e19db1628581d5587a0a8
-    sha256: 7d976f5702ad078abfd6d2f3e266a64f2736f7906f55676fa97a25ce2911a2f3
-  category: notebooks
-  optional: true
-- name: msgpack-python
-  version: 1.2.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/msgpack-python-1.2.1-py313he6111f0_0.conda
-  hash:
-    md5: 6c8e30755c2e19db1628581d5587a0a8
-    sha256: 7d976f5702ad078abfd6d2f3e266a64f2736f7906f55676fa97a25ce2911a2f3
+    md5: 8719ecf11d26a8ce40a2cedb488e2d07
+    sha256: 5ef226c019a75458bdb4354dacb380d324edfa1c3cf047744dd6189e0a13a4c6
   category: tools
   optional: true
 - name: msgpack-python
@@ -26576,42 +20542,12 @@ package:
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-    python: '>=3.13,<3.14.0a0'
+    python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.2.1-py313h862c624_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.2.1-py313h224b87c_1.conda
   hash:
-    md5: ad0e8564023d0f623c10649d755116e6
-    sha256: 816f16edc11caa675daba47419eb438cf9df88f74c0d5ffd05d1428c9d3e9158
-  category: container
-  optional: true
-- name: msgpack-python
-  version: 1.2.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.2.1-py313h862c624_0.conda
-  hash:
-    md5: ad0e8564023d0f623c10649d755116e6
-    sha256: 816f16edc11caa675daba47419eb438cf9df88f74c0d5ffd05d1428c9d3e9158
-  category: notebooks
-  optional: true
-- name: msgpack-python
-  version: 1.2.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.2.1-py313h862c624_0.conda
-  hash:
-    md5: ad0e8564023d0f623c10649d755116e6
-    sha256: 816f16edc11caa675daba47419eb438cf9df88f74c0d5ffd05d1428c9d3e9158
+    md5: 96ac9dca0672f882f99f3feec1349f02
+    sha256: 7d2406005a155805ffb4dfe5b5cffc1ddb3645058999a07dee055a6a172a4899
   category: tools
   optional: true
 - name: msgpack-python
@@ -26621,42 +20557,12 @@ package:
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-    python: '>=3.13,<3.14.0a0'
+    python: 3.13.*
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.2.1-py313h5c29297_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.2.1-py313h2af2deb_1.conda
   hash:
-    md5: b929e2af3d4059fedfb0a5da0007556f
-    sha256: 12f2c785c34a465f399e7af89e6b88a86684bde704e25460789e83efc0d8fd87
-  category: container
-  optional: true
-- name: msgpack-python
-  version: 1.2.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.2.1-py313h5c29297_0.conda
-  hash:
-    md5: b929e2af3d4059fedfb0a5da0007556f
-    sha256: 12f2c785c34a465f399e7af89e6b88a86684bde704e25460789e83efc0d8fd87
-  category: notebooks
-  optional: true
-- name: msgpack-python
-  version: 1.2.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.2.1-py313h5c29297_0.conda
-  hash:
-    md5: b929e2af3d4059fedfb0a5da0007556f
-    sha256: 12f2c785c34a465f399e7af89e6b88a86684bde704e25460789e83efc0d8fd87
+    md5: f4aec3b27ac208543c6f19a9a783caee
+    sha256: b3a134697c01b05906e23c5ba94ffad6b2647d20a5126f0fe1e1a973dd7f627a
   category: tools
   optional: true
 - name: muparser
@@ -26714,102 +20620,6 @@ package:
     sha256: 5533e7e3d4b0819b4426f8a1b3f680e6b9c922cdae2b7fabcd0e8c59df22772a
   category: notebooks
   optional: true
-- name: narwhals
-  version: 2.22.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
-  hash:
-    md5: 9450fb40fb1e147d0bcbdf07cd02ca96
-    sha256: dd2744a501f2db0aef084566bf3d0c2b312661dc91beb5a4cc97d27cdda0a959
-  category: container
-  optional: true
-- name: narwhals
-  version: 2.22.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
-  hash:
-    md5: 9450fb40fb1e147d0bcbdf07cd02ca96
-    sha256: dd2744a501f2db0aef084566bf3d0c2b312661dc91beb5a4cc97d27cdda0a959
-  category: notebooks
-  optional: true
-- name: narwhals
-  version: 2.22.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
-  hash:
-    md5: 9450fb40fb1e147d0bcbdf07cd02ca96
-    sha256: dd2744a501f2db0aef084566bf3d0c2b312661dc91beb5a4cc97d27cdda0a959
-  category: container
-  optional: true
-- name: narwhals
-  version: 2.22.1
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
-  hash:
-    md5: 9450fb40fb1e147d0bcbdf07cd02ca96
-    sha256: dd2744a501f2db0aef084566bf3d0c2b312661dc91beb5a4cc97d27cdda0a959
-  category: notebooks
-  optional: true
-- name: narwhals
-  version: 2.22.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
-  hash:
-    md5: 9450fb40fb1e147d0bcbdf07cd02ca96
-    sha256: dd2744a501f2db0aef084566bf3d0c2b312661dc91beb5a4cc97d27cdda0a959
-  category: container
-  optional: true
-- name: narwhals
-  version: 2.22.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
-  hash:
-    md5: 9450fb40fb1e147d0bcbdf07cd02ca96
-    sha256: dd2744a501f2db0aef084566bf3d0c2b312661dc91beb5a4cc97d27cdda0a959
-  category: notebooks
-  optional: true
-- name: narwhals
-  version: 2.22.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
-  hash:
-    md5: 9450fb40fb1e147d0bcbdf07cd02ca96
-    sha256: dd2744a501f2db0aef084566bf3d0c2b312661dc91beb5a4cc97d27cdda0a959
-  category: container
-  optional: true
-- name: narwhals
-  version: 2.22.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.22.1-pyhcf101f3_0.conda
-  hash:
-    md5: 9450fb40fb1e147d0bcbdf07cd02ca96
-    sha256: dd2744a501f2db0aef084566bf3d0c2b312661dc91beb5a4cc97d27cdda0a959
-  category: notebooks
-  optional: true
 - name: nbclient
   version: 0.11.0
   manager: conda
@@ -27075,7 +20885,7 @@ package:
     packaging: ''
     pandocfilters: '>=1.4.1'
     pygments: '>=2.4.1'
-    python: ''
+    python: '>=3.10'
     traitlets: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
   hash:
@@ -27102,7 +20912,7 @@ package:
     packaging: ''
     pandocfilters: '>=1.4.1'
     pygments: '>=2.4.1'
-    python: ''
+    python: '>=3.10'
     traitlets: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
   hash:
@@ -27129,7 +20939,7 @@ package:
     packaging: ''
     pandocfilters: '>=1.4.1'
     pygments: '>=2.4.1'
-    python: ''
+    python: '>=3.10'
     traitlets: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
   hash:
@@ -27156,7 +20966,7 @@ package:
     packaging: ''
     pandocfilters: '>=1.4.1'
     pygments: '>=2.4.1'
-    python: ''
+    python: '>=3.10'
     traitlets: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
   hash:
@@ -27183,7 +20993,7 @@ package:
     packaging: ''
     pandocfilters: '>=1.4.1'
     pygments: '>=2.4.1'
-    python: ''
+    python: '>=3.10'
     traitlets: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
   hash:
@@ -27210,7 +21020,7 @@ package:
     packaging: ''
     pandocfilters: '>=1.4.1'
     pygments: '>=2.4.1'
-    python: ''
+    python: '>=3.10'
     traitlets: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
   hash:
@@ -27500,7 +21310,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio2-1.7.2-pyhcf101f3_0.conda
   hash:
     md5: fcd832bfd4749e9b246112b6894f97fc
@@ -27512,7 +21322,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio2-1.7.2-pyhcf101f3_0.conda
   hash:
     md5: fcd832bfd4749e9b246112b6894f97fc
@@ -27524,7 +21334,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio2-1.7.2-pyhcf101f3_0.conda
   hash:
     md5: fcd832bfd4749e9b246112b6894f97fc
@@ -27536,7 +21346,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio2-1.7.2-pyhcf101f3_0.conda
   hash:
     md5: fcd832bfd4749e9b246112b6894f97fc
@@ -27548,7 +21358,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio2-1.7.2-pyhcf101f3_0.conda
   hash:
     md5: fcd832bfd4749e9b246112b6894f97fc
@@ -27560,7 +21370,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio2-1.7.2-pyhcf101f3_0.conda
   hash:
     md5: fcd832bfd4749e9b246112b6894f97fc
@@ -27572,7 +21382,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio2-1.7.2-pyhcf101f3_0.conda
   hash:
     md5: fcd832bfd4749e9b246112b6894f97fc
@@ -27584,7 +21394,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio2-1.7.2-pyhcf101f3_0.conda
   hash:
     md5: fcd832bfd4749e9b246112b6894f97fc
@@ -27596,7 +21406,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio2-1.7.2-pyhcf101f3_0.conda
   hash:
     md5: fcd832bfd4749e9b246112b6894f97fc
@@ -27613,17 +21423,17 @@ package:
     certifi: ''
     cftime: ''
     cpython: '>=3.11'
-    hdf5: '>=1.14.6,<1.14.7.0a0'
+    hdf5: '>=2.1.0,<3.0a0'
     libgcc: '>=14'
     libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     numpy: '>=1.23,<3'
     packaging: ''
     python: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.4-nompi_py311ha0596eb_108.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.4-nompi_py311h498b1eb_108.conda
   hash:
-    md5: f610e09997fa06e55f150685aa07ddb8
-    sha256: 36297e47f337520963b2240676178900964ce1cc8d5ad474d8414737ba9fc100
+    md5: 00192630eb74c7fa6e5e3e84686777fb
+    sha256: e000f6cee00d8ec94000ec71f0c880913c11bb50f8e695dbdd930f95546accfa
   category: notebooks
   optional: true
 - name: netcdf4
@@ -27658,16 +21468,16 @@ package:
     certifi: ''
     cftime: ''
     cpython: '>=3.11'
-    hdf5: '>=1.14.6,<1.14.7.0a0'
+    hdf5: '>=2.1.0,<3.0a0'
     libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     numpy: '>=1.23,<3'
     packaging: ''
     python: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.7.4-nompi_py311hd72b3df_108.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.7.4-nompi_py311h8ff4399_108.conda
   hash:
-    md5: 68f15c61f83a5277725c72f96647df8f
-    sha256: e6855b7a0ae86ed5fe18f75a929472b4182c41628ba329172a982bc33136d569
+    md5: 86f0d4f75bd26135a218395d05d8057c
+    sha256: 36c145f8e5d4b6407333e7c6c0d01470e62c3a553b1c607a0ac19f92f422fe8f
   category: notebooks
   optional: true
 - name: netcdf4
@@ -27721,7 +21531,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.11'
   url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
   hash:
     md5: a2c1eeadae7a309daed9d62c96012a2b
@@ -27733,7 +21543,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.11'
   url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
   hash:
     md5: a2c1eeadae7a309daed9d62c96012a2b
@@ -27745,7 +21555,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.11'
   url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
   hash:
     md5: a2c1eeadae7a309daed9d62c96012a2b
@@ -27757,7 +21567,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.11'
   url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
   hash:
     md5: a2c1eeadae7a309daed9d62c96012a2b
@@ -27769,7 +21579,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.11'
   url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
   hash:
     md5: a2c1eeadae7a309daed9d62c96012a2b
@@ -27781,100 +21591,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.11'
   url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
   hash:
     md5: a2c1eeadae7a309daed9d62c96012a2b
     sha256: f6a82172afc50e54741f6f84527ef10424326611503c64e359e25a19a8e4c1c6
   category: tools
-  optional: true
-- name: nlohmann_json
-  version: 3.12.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
-  hash:
-    md5: 16c2a0e9c4a166e53632cfca4f68d020
-    sha256: fd2cbd8dfc006c72f45843672664a8e4b99b2f8137654eaae8c3d46dca776f63
-  category: container
-  optional: true
-- name: nlohmann_json
-  version: 3.12.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
-  hash:
-    md5: 16c2a0e9c4a166e53632cfca4f68d020
-    sha256: fd2cbd8dfc006c72f45843672664a8e4b99b2f8137654eaae8c3d46dca776f63
-  category: notebooks
-  optional: true
-- name: nlohmann_json
-  version: 3.12.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nlohmann_json-3.12.0-h7ac5ae9_1.conda
-  hash:
-    md5: 6cbb2594cea5f2cc2907170655852ba9
-    sha256: 03b4ffbcd3c20276f6fd9743e2d7fc8c4bed2006ac4481d90ee8f2a5d74acd5d
-  category: container
-  optional: true
-- name: nlohmann_json
-  version: 3.12.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nlohmann_json-3.12.0-h7ac5ae9_1.conda
-  hash:
-    md5: 6cbb2594cea5f2cc2907170655852ba9
-    sha256: 03b4ffbcd3c20276f6fd9743e2d7fc8c4bed2006ac4481d90ee8f2a5d74acd5d
-  category: notebooks
-  optional: true
-- name: nlohmann_json
-  version: 3.12.0
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/nlohmann_json-3.12.0-h06076ce_1.conda
-  hash:
-    md5: 97d7a1cda5546cb0bbdefa3777cb9897
-    sha256: 8e1b8ac88e07da2910c72466a94d1fc77aa13c722f8ddbc7ae3beb7c19b41fc7
-  category: container
-  optional: true
-- name: nlohmann_json
-  version: 3.12.0
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/nlohmann_json-3.12.0-h06076ce_1.conda
-  hash:
-    md5: 97d7a1cda5546cb0bbdefa3777cb9897
-    sha256: 8e1b8ac88e07da2910c72466a94d1fc77aa13c722f8ddbc7ae3beb7c19b41fc7
-  category: notebooks
-  optional: true
-- name: nlohmann_json
-  version: 3.12.0
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_1.conda
-  hash:
-    md5: 755cfa6c08ed7b7acbee20ccbf15a47c
-    sha256: 1945fd5b64b74ef3d57926156fb0bfe88ee637c49f3273067f7231b224f1d26d
-  category: container
-  optional: true
-- name: nlohmann_json
-  version: 3.12.0
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_1.conda
-  hash:
-    md5: 755cfa6c08ed7b7acbee20ccbf15a47c
-    sha256: 1945fd5b64b74ef3d57926156fb0bfe88ee637c49f3273067f7231b224f1d26d
-  category: notebooks
   optional: true
 - name: nodejs
   version: 20.20.2
@@ -27885,14 +21607,14 @@ package:
     icu: '>=78.3,<79.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    libuv: '>=1.51.0,<2.0a0'
+    libuv: '>=1.52.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.5,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-20.20.2-h44b80ee_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-20.20.2-h44b80ee_1.conda
   hash:
-    md5: 113e0116af867d4d96325b5b93d984c5
-    sha256: 9a4af21d212e0b4aa8ed2b8c14786560a2923554d7ae1a8cd77ba9952e81b3af
+    md5: 0022b6d3b459372b6cce6fc9d973adf3
+    sha256: ec1189785e9a5201b051643b974ff8611ec7caaea9f26748577ac77a0d4d7839
   category: container
   optional: true
 - name: nodejs
@@ -27903,14 +21625,14 @@ package:
     icu: '>=78.3,<79.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    libuv: '>=1.51.0,<2.0a0'
+    libuv: '>=1.52.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.5,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nodejs-20.20.2-hd05b721_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nodejs-20.20.2-hd05b721_1.conda
   hash:
-    md5: 1094d08ad5801e1db50aa6eb08e6b7c2
-    sha256: 7f76af9f6f488936a125ad1411e0dd730174ab1921f131a98b1ea4d1862aeef4
+    md5: b247e655744023800faeb69aba690756
+    sha256: 0b227c9b31f925664cd078e2e395f16ce9c5bda2bc07b9c5fefec40e1eb922b9
   category: container
   optional: true
 - name: nodejs
@@ -27963,17 +21685,6 @@ package:
 - name: nomkl
   version: '1.0'
   manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
-  hash:
-    md5: 9a66894dfd07c4510beb6b3f9672ccc0
-    sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
-  category: notebooks
-  optional: true
-- name: nomkl
-  version: '1.0'
-  manager: conda
   platform: osx-arm64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
@@ -28010,7 +21721,7 @@ package:
     jupyterlab: '>=4.5.8,<4.6'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2,<0.3'
-    python: ''
+    python: '>=3.10'
     tornado: '>=6.2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.5.7-pyhcf101f3_1.conda
   hash:
@@ -28028,7 +21739,7 @@ package:
     jupyterlab: '>=4.5.8,<4.6'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2,<0.3'
-    python: ''
+    python: '>=3.10'
     tornado: '>=6.2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.5.7-pyhcf101f3_1.conda
   hash:
@@ -28046,7 +21757,7 @@ package:
     jupyterlab: '>=4.5.8,<4.6'
     jupyterlab_server: '>=2.28.0,<3'
     notebook-shim: '>=0.2,<0.3'
-    python: ''
+    python: '>=3.10'
     tornado: '>=6.2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.5.7-pyhcf101f3_1.conda
   hash:
@@ -28514,160 +22225,6 @@ package:
     sha256: 80008386bb19f8dffc8873d6c1c16f22bb63f19c960d774b647b9a01e99ad624
   category: notebooks
   optional: true
-- name: openblas
-  version: 0.3.33
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libopenblas: 0.3.33
-  url: https://conda.anaconda.org/conda-forge/linux-64/openblas-0.3.33-pthreads_h6ec200e_0.conda
-  hash:
-    md5: 7ed92a9ace1e050a2eca9fe50aa94c81
-    sha256: 52817270f04566a1c5c0a6190212ca6c4d8e58127ba2cf2699493682862bdedf
-  category: notebooks
-  optional: true
-- name: openblas
-  version: 0.3.33
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libopenblas: 0.3.33
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openblas-0.3.33-openmp_hb2b1217_0.conda
-  hash:
-    md5: 5a59eca4ab1feff2bd64c2bc5d9d3f74
-    sha256: e8232201485b5caf891a41e707194618d8d56e56ffb9541e4e6a6f988acc0479
-  category: notebooks
-  optional: true
-- name: openjpeg
-  version: 2.5.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libpng: '>=1.6.50,<1.7.0a0'
-    libstdcxx: '>=14'
-    libtiff: '>=4.7.1,<4.8.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-  hash:
-    md5: 11b3379b191f63139e29c0d19dee24cd
-    sha256: 3900f9f2dbbf4129cf3ad6acf4e4b6f7101390b53843591c53b00f034343bc4d
-  category: container
-  optional: true
-- name: openjpeg
-  version: 2.5.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libpng: '>=1.6.50,<1.7.0a0'
-    libstdcxx: '>=14'
-    libtiff: '>=4.7.1,<4.8.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-  hash:
-    md5: 11b3379b191f63139e29c0d19dee24cd
-    sha256: 3900f9f2dbbf4129cf3ad6acf4e4b6f7101390b53843591c53b00f034343bc4d
-  category: notebooks
-  optional: true
-- name: openjpeg
-  version: 2.5.4
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libpng: '>=1.6.50,<1.7.0a0'
-    libstdcxx: '>=14'
-    libtiff: '>=4.7.1,<4.8.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
-  hash:
-    md5: cea962410e327262346d48d01f05936c
-    sha256: bd1bc8bdde5e6c5cbac42d462b939694e40b59be6d0698f668515908640c77b8
-  category: container
-  optional: true
-- name: openjpeg
-  version: 2.5.4
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libpng: '>=1.6.50,<1.7.0a0'
-    libstdcxx: '>=14'
-    libtiff: '>=4.7.1,<4.8.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
-  hash:
-    md5: cea962410e327262346d48d01f05936c
-    sha256: bd1bc8bdde5e6c5cbac42d462b939694e40b59be6d0698f668515908640c77b8
-  category: notebooks
-  optional: true
-- name: openjpeg
-  version: 2.5.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=19'
-    libpng: '>=1.6.50,<1.7.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.4-h87e8dc5_0.conda
-  hash:
-    md5: a67d3517ebbf615b91ef9fdc99934e0c
-    sha256: fdf4708a4e45b5fd9868646dd0c0a78429f4c0b8be490196c975e06403a841d0
-  category: container
-  optional: true
-- name: openjpeg
-  version: 2.5.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=19'
-    libpng: '>=1.6.50,<1.7.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.4-h87e8dc5_0.conda
-  hash:
-    md5: a67d3517ebbf615b91ef9fdc99934e0c
-    sha256: fdf4708a4e45b5fd9868646dd0c0a78429f4c0b8be490196c975e06403a841d0
-  category: notebooks
-  optional: true
-- name: openjpeg
-  version: 2.5.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    libpng: '>=1.6.55,<1.7.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
-  hash:
-    md5: 4b5d3a91320976eec71678fad1e3569b
-    sha256: 60aca8b9f94d06b852b296c276b3cf0efba5a6eb9f25feb8708570d3a74f00e4
-  category: container
-  optional: true
-- name: openjpeg
-  version: 2.5.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    libpng: '>=1.6.55,<1.7.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
-  hash:
-    md5: 4b5d3a91320976eec71678fad1e3569b
-    sha256: 60aca8b9f94d06b852b296c276b3cf0efba5a6eb9f25feb8708570d3a74f00e4
-  category: notebooks
-  optional: true
 - name: openssl
   version: 3.6.3
   manager: conda
@@ -28786,168 +22343,6 @@ package:
     sha256: 8ed106b6d0c14ddc43dc4774b5c7a96e0d208308e1e377037a01b70ecc4ede05
   category: notebooks
   optional: true
-- name: orc
-  version: 2.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libabseil: '*'
-    libgcc: '>=14'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    snappy: '>=1.2.2,<1.3.0a0'
-    tzdata: ''
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.3.0-h21090e2_0.conda
-  hash:
-    md5: 8027fce94fdfdf2e54f9d18cbae496df
-    sha256: a60c2578c8422e0c67206d269767feb4d3e627511558b6866e5daf2231d5214d
-  category: container
-  optional: true
-- name: orc
-  version: 2.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libabseil: '*'
-    libgcc: '>=14'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    snappy: '>=1.2.2,<1.3.0a0'
-    tzdata: ''
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.3.0-h21090e2_0.conda
-  hash:
-    md5: 8027fce94fdfdf2e54f9d18cbae496df
-    sha256: a60c2578c8422e0c67206d269767feb4d3e627511558b6866e5daf2231d5214d
-  category: notebooks
-  optional: true
-- name: orc
-  version: 2.3.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libabseil: '*'
-    libgcc: '>=14'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    snappy: '>=1.2.2,<1.3.0a0'
-    tzdata: ''
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/orc-2.3.0-hce1ac79_0.conda
-  hash:
-    md5: 62f1cfadc1aa30f3c0ec5948996bbc6b
-    sha256: c44a1d88d4ef953ca897f795b772b4b2b900d98c2ef815d956c79d82dd91115b
-  category: container
-  optional: true
-- name: orc
-  version: 2.3.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libabseil: '*'
-    libgcc: '>=14'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    snappy: '>=1.2.2,<1.3.0a0'
-    tzdata: ''
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/orc-2.3.0-hce1ac79_0.conda
-  hash:
-    md5: 62f1cfadc1aa30f3c0ec5948996bbc6b
-    sha256: c44a1d88d4ef953ca897f795b772b4b2b900d98c2ef815d956c79d82dd91115b
-  category: notebooks
-  optional: true
-- name: orc
-  version: 2.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '*'
-    libcxx: '>=19'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    snappy: '>=1.2.2,<1.3.0a0'
-    tzdata: ''
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/orc-2.3.0-hb9b210e_0.conda
-  hash:
-    md5: 292d30447800bc51a0d3e0e9738f5730
-    sha256: c4872822be78b2503bba06b906604c87000e3a63c7b7b8cb459463d46c55814b
-  category: container
-  optional: true
-- name: orc
-  version: 2.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '*'
-    libcxx: '>=19'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    snappy: '>=1.2.2,<1.3.0a0'
-    tzdata: ''
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/orc-2.3.0-hb9b210e_0.conda
-  hash:
-    md5: 292d30447800bc51a0d3e0e9738f5730
-    sha256: c4872822be78b2503bba06b906604c87000e3a63c7b7b8cb459463d46c55814b
-  category: notebooks
-  optional: true
-- name: orc
-  version: 2.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '*'
-    libcxx: '>=19'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    snappy: '>=1.2.2,<1.3.0a0'
-    tzdata: ''
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.3.0-hd11884d_0.conda
-  hash:
-    md5: 77bfe521901c1a247cc66c1276826a85
-    sha256: 8594f064828cca9b8d625e2ebe79436fd4ffc030c950573380c54a8f4329f955
-  category: container
-  optional: true
-- name: orc
-  version: 2.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '*'
-    libcxx: '>=19'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    snappy: '>=1.2.2,<1.3.0a0'
-    tzdata: ''
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.3.0-hd11884d_0.conda
-  hash:
-    md5: 77bfe521901c1a247cc66c1276826a85
-    sha256: 8594f064828cca9b8d625e2ebe79436fd4ffc030c950573380c54a8f4329f955
-  category: notebooks
-  optional: true
 - name: overrides
   version: 7.7.0
   manager: conda
@@ -29105,7 +22500,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   hash:
     md5: 4c06a92e74452cfa53623a81592e8934
@@ -29117,7 +22512,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   hash:
     md5: 4c06a92e74452cfa53623a81592e8934
@@ -29129,7 +22524,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   hash:
     md5: 4c06a92e74452cfa53623a81592e8934
@@ -29141,7 +22536,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   hash:
     md5: 4c06a92e74452cfa53623a81592e8934
@@ -29153,7 +22548,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   hash:
     md5: 4c06a92e74452cfa53623a81592e8934
@@ -29165,7 +22560,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   hash:
     md5: 4c06a92e74452cfa53623a81592e8934
@@ -29177,7 +22572,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   hash:
     md5: 4c06a92e74452cfa53623a81592e8934
@@ -29189,7 +22584,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   hash:
     md5: 4c06a92e74452cfa53623a81592e8934
@@ -29201,7 +22596,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   hash:
     md5: 4c06a92e74452cfa53623a81592e8934
@@ -29213,7 +22608,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   hash:
     md5: 4c06a92e74452cfa53623a81592e8934
@@ -29225,7 +22620,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   hash:
     md5: 4c06a92e74452cfa53623a81592e8934
@@ -29237,7 +22632,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   hash:
     md5: 4c06a92e74452cfa53623a81592e8934
@@ -29292,144 +22687,6 @@ package:
     sha256: 41b074a35b210b3395ccd10d30c301c0f7c65150353820f3a6a7d2bf8be5beaa
   category: container
   optional: true
-- name: pandas
-  version: 3.0.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    numpy: '>=1.23,<3'
-    python: ''
-    python-dateutil: '>=2.8.2'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.3-py313hbfd7664_0.conda
-  hash:
-    md5: 70d4dd67877354f6912af31177cb1117
-    sha256: a02d58327a57eb2f149c040b31c758fc6acea7c6aa5cb09b40b146eb6ed637d9
-  category: container
-  optional: true
-- name: pandas
-  version: 3.0.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    numpy: '>=1.23,<3'
-    python: ''
-    python-dateutil: '>=2.8.2'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.3-py313hbfd7664_0.conda
-  hash:
-    md5: 70d4dd67877354f6912af31177cb1117
-    sha256: a02d58327a57eb2f149c040b31c758fc6acea7c6aa5cb09b40b146eb6ed637d9
-  category: notebooks
-  optional: true
-- name: pandas
-  version: 3.0.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    numpy: '>=1.23,<3'
-    python: 3.13.*
-    python-dateutil: '>=2.8.2'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pandas-3.0.3-py313h59403f9_0.conda
-  hash:
-    md5: 0598209a92da1c3a6a76089b875d2bb4
-    sha256: ef041fd56556327bca81611e3aa46e19793fd89999637f19949f735f7e8f47b2
-  category: container
-  optional: true
-- name: pandas
-  version: 3.0.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    numpy: '>=1.23,<3'
-    python: 3.13.*
-    python-dateutil: '>=2.8.2'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pandas-3.0.3-py313h59403f9_0.conda
-  hash:
-    md5: 0598209a92da1c3a6a76089b875d2bb4
-    sha256: ef041fd56556327bca81611e3aa46e19793fd89999637f19949f735f7e8f47b2
-  category: notebooks
-  optional: true
-- name: pandas
-  version: 3.0.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    numpy: '>=1.23,<3'
-    python: ''
-    python-dateutil: '>=2.8.2'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pandas-3.0.3-py313hfd25234_0.conda
-  hash:
-    md5: 4942165df70ab41f6487ceaa0ff6bb67
-    sha256: e544e54be83b7be300813a3503ca915c8a7c6e82f550e616326732a9d9d09014
-  category: container
-  optional: true
-- name: pandas
-  version: 3.0.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    numpy: '>=1.23,<3'
-    python: ''
-    python-dateutil: '>=2.8.2'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pandas-3.0.3-py313hfd25234_0.conda
-  hash:
-    md5: 4942165df70ab41f6487ceaa0ff6bb67
-    sha256: e544e54be83b7be300813a3503ca915c8a7c6e82f550e616326732a9d9d09014
-  category: notebooks
-  optional: true
-- name: pandas
-  version: 3.0.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    numpy: '>=1.23,<3'
-    python: 3.13.*
-    python-dateutil: '>=2.8.2'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-3.0.3-py313h1188861_0.conda
-  hash:
-    md5: 12dd2c60321105aa1f869373ae27de42
-    sha256: 5fd41083894c2b7b9ba3f02a0d4ddbab17c6c1f645fdc1f3f1325522eb2a1a28
-  category: container
-  optional: true
-- name: pandas
-  version: 3.0.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    numpy: '>=1.23,<3'
-    python: 3.13.*
-    python-dateutil: '>=2.8.2'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-3.0.3-py313h1188861_0.conda
-  hash:
-    md5: 12dd2c60321105aa1f869373ae27de42
-    sha256: 5fd41083894c2b7b9ba3f02a0d4ddbab17c6c1f645fdc1f3f1325522eb2a1a28
-  category: notebooks
-  optional: true
 - name: pandocfilters
   version: 1.5.0
   manager: conda
@@ -29579,7 +22836,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
   hash:
     md5: 39894c952938276405a1bd30e4ce2caf
@@ -29591,7 +22848,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
   hash:
     md5: 39894c952938276405a1bd30e4ce2caf
@@ -29603,7 +22860,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
   hash:
     md5: 39894c952938276405a1bd30e4ce2caf
@@ -29615,7 +22872,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
   hash:
     md5: 39894c952938276405a1bd30e4ce2caf
@@ -29627,7 +22884,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
   hash:
     md5: 39894c952938276405a1bd30e4ce2caf
@@ -29639,7 +22896,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
   hash:
     md5: 39894c952938276405a1bd30e4ce2caf
@@ -29651,7 +22908,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
   hash:
     md5: 39894c952938276405a1bd30e4ce2caf
@@ -29663,7 +22920,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
   hash:
     md5: 39894c952938276405a1bd30e4ce2caf
@@ -29675,7 +22932,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
   hash:
     md5: 39894c952938276405a1bd30e4ce2caf
@@ -29687,7 +22944,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
   hash:
     md5: 39894c952938276405a1bd30e4ce2caf
@@ -29699,7 +22956,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
   hash:
     md5: 39894c952938276405a1bd30e4ce2caf
@@ -29711,124 +22968,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
   hash:
     md5: 39894c952938276405a1bd30e4ce2caf
     sha256: 611882f7944b467281c46644ffde6c5145d1a7730388bcde26e7e86819b0998e
   category: tools
-  optional: true
-- name: partd
-  version: 1.4.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    locket: ''
-    python: '>=3.9'
-    toolz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0badf9c54e24cecfb0ad2f99d680c163
-    sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
-  category: container
-  optional: true
-- name: partd
-  version: 1.4.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    locket: ''
-    python: '>=3.9'
-    toolz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0badf9c54e24cecfb0ad2f99d680c163
-    sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
-  category: notebooks
-  optional: true
-- name: partd
-  version: 1.4.2
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    locket: ''
-    python: '>=3.9'
-    toolz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0badf9c54e24cecfb0ad2f99d680c163
-    sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
-  category: container
-  optional: true
-- name: partd
-  version: 1.4.2
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    locket: ''
-    python: '>=3.9'
-    toolz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0badf9c54e24cecfb0ad2f99d680c163
-    sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
-  category: notebooks
-  optional: true
-- name: partd
-  version: 1.4.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    locket: ''
-    python: '>=3.9'
-    toolz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0badf9c54e24cecfb0ad2f99d680c163
-    sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
-  category: container
-  optional: true
-- name: partd
-  version: 1.4.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    locket: ''
-    python: '>=3.9'
-    toolz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0badf9c54e24cecfb0ad2f99d680c163
-    sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
-  category: notebooks
-  optional: true
-- name: partd
-  version: 1.4.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    locket: ''
-    python: '>=3.9'
-    toolz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0badf9c54e24cecfb0ad2f99d680c163
-    sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
-  category: container
-  optional: true
-- name: partd
-  version: 1.4.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    locket: ''
-    python: '>=3.9'
-    toolz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0badf9c54e24cecfb0ad2f99d680c163
-    sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
-  category: notebooks
   optional: true
 - name: pcre2
   version: '10.47'
@@ -30124,200 +23269,6 @@ package:
     sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
   category: tools
   optional: true
-- name: pillow
-  version: 12.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    lcms2: '>=2.18,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libgcc: '>=14'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-    libwebp-base: '>=1.6.0,<2.0a0'
-    libxcb: '>=1.17.0,<2.0a0'
-    openjpeg: '>=2.5.4,<3.0a0'
-    python: ''
-    python_abi: 3.13.*
-    tk: '>=8.6.13,<8.7.0a0'
-    zlib-ng: '>=2.3.3,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py313h80991f8_0.conda
-  hash:
-    md5: 7245f1bbf52ed5e3818d742f51b44a7d
-    sha256: 55a76548bb003ff6deac9bf209b279d428030f230632fb70f15ae153aed05158
-  category: container
-  optional: true
-- name: pillow
-  version: 12.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    lcms2: '>=2.18,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libgcc: '>=14'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-    libwebp-base: '>=1.6.0,<2.0a0'
-    libxcb: '>=1.17.0,<2.0a0'
-    openjpeg: '>=2.5.4,<3.0a0'
-    python: ''
-    python_abi: 3.13.*
-    tk: '>=8.6.13,<8.7.0a0'
-    zlib-ng: '>=2.3.3,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py313h80991f8_0.conda
-  hash:
-    md5: 7245f1bbf52ed5e3818d742f51b44a7d
-    sha256: 55a76548bb003ff6deac9bf209b279d428030f230632fb70f15ae153aed05158
-  category: notebooks
-  optional: true
-- name: pillow
-  version: 12.2.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    lcms2: '>=2.18,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libgcc: '>=14'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-    libwebp-base: '>=1.6.0,<2.0a0'
-    libxcb: '>=1.17.0,<2.0a0'
-    openjpeg: '>=2.5.4,<3.0a0'
-    python: 3.13.*
-    python_abi: 3.13.*
-    tk: '>=8.6.13,<8.7.0a0'
-    zlib-ng: '>=2.3.3,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.2.0-py313h20c1486_0.conda
-  hash:
-    md5: a835906605f75b8726930a368455e8d2
-    sha256: bafd1dc6fe5ac317625e4bb3f50735fe3b45205b079dc3509b621817b02e7785
-  category: container
-  optional: true
-- name: pillow
-  version: 12.2.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    lcms2: '>=2.18,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libgcc: '>=14'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-    libwebp-base: '>=1.6.0,<2.0a0'
-    libxcb: '>=1.17.0,<2.0a0'
-    openjpeg: '>=2.5.4,<3.0a0'
-    python: 3.13.*
-    python_abi: 3.13.*
-    tk: '>=8.6.13,<8.7.0a0'
-    zlib-ng: '>=2.3.3,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.2.0-py313h20c1486_0.conda
-  hash:
-    md5: a835906605f75b8726930a368455e8d2
-    sha256: bafd1dc6fe5ac317625e4bb3f50735fe3b45205b079dc3509b621817b02e7785
-  category: notebooks
-  optional: true
-- name: pillow
-  version: 12.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    lcms2: '>=2.18,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-    libwebp-base: '>=1.6.0,<2.0a0'
-    libxcb: '>=1.17.0,<2.0a0'
-    openjpeg: '>=2.5.4,<3.0a0'
-    python: ''
-    python_abi: 3.13.*
-    tk: '>=8.6.13,<8.7.0a0'
-    zlib-ng: '>=2.3.3,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-12.2.0-py313h23d381d_0.conda
-  hash:
-    md5: 69e4cefea9c222ea64b219df6ba5787d
-    sha256: 60f721fb766c585c370e1a936754163652cd9f4fd33bda5202ebcf38d502abd2
-  category: container
-  optional: true
-- name: pillow
-  version: 12.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    lcms2: '>=2.18,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-    libwebp-base: '>=1.6.0,<2.0a0'
-    libxcb: '>=1.17.0,<2.0a0'
-    openjpeg: '>=2.5.4,<3.0a0'
-    python: ''
-    python_abi: 3.13.*
-    tk: '>=8.6.13,<8.7.0a0'
-    zlib-ng: '>=2.3.3,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-12.2.0-py313h23d381d_0.conda
-  hash:
-    md5: 69e4cefea9c222ea64b219df6ba5787d
-    sha256: 60f721fb766c585c370e1a936754163652cd9f4fd33bda5202ebcf38d502abd2
-  category: notebooks
-  optional: true
-- name: pillow
-  version: 12.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    lcms2: '>=2.18,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-    libwebp-base: '>=1.6.0,<2.0a0'
-    libxcb: '>=1.17.0,<2.0a0'
-    openjpeg: '>=2.5.4,<3.0a0'
-    python: 3.13.*
-    python_abi: 3.13.*
-    tk: '>=8.6.13,<8.7.0a0'
-    zlib-ng: '>=2.3.3,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.2.0-py313h45e5a15_0.conda
-  hash:
-    md5: 6186601fd72a394a6f7c7b7096f6a063
-    sha256: 90333643a7868b10724999633bb393d005bc5f539d05666f80c41fb67e5f0f3f
-  category: container
-  optional: true
-- name: pillow
-  version: 12.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    lcms2: '>=2.18,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-    libwebp-base: '>=1.6.0,<2.0a0'
-    libxcb: '>=1.17.0,<2.0a0'
-    openjpeg: '>=2.5.4,<3.0a0'
-    python: 3.13.*
-    python_abi: 3.13.*
-    tk: '>=8.6.13,<8.7.0a0'
-    zlib-ng: '>=2.3.3,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.2.0-py313h45e5a15_0.conda
-  hash:
-    md5: 6186601fd72a394a6f7c7b7096f6a063
-    sha256: 90333643a7868b10724999633bb393d005bc5f539d05666f80c41fb67e5f0f3f
-  category: notebooks
-  optional: true
 - name: pip
   version: 26.1.2
   manager: conda
@@ -30455,7 +23406,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
   hash:
     md5: 2c5ef45db85d34799771629bd5860fd7
@@ -30467,7 +23418,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
   hash:
     md5: 2c5ef45db85d34799771629bd5860fd7
@@ -30479,7 +23430,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
   hash:
     md5: 2c5ef45db85d34799771629bd5860fd7
@@ -30491,7 +23442,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
   hash:
     md5: 2c5ef45db85d34799771629bd5860fd7
@@ -30503,7 +23454,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
   hash:
     md5: 2c5ef45db85d34799771629bd5860fd7
@@ -30515,7 +23466,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
   hash:
     md5: 2c5ef45db85d34799771629bd5860fd7
@@ -30527,7 +23478,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
   hash:
     md5: 2c5ef45db85d34799771629bd5860fd7
@@ -30539,7 +23490,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
   hash:
     md5: 2c5ef45db85d34799771629bd5860fd7
@@ -30551,7 +23502,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
   hash:
     md5: 2c5ef45db85d34799771629bd5860fd7
@@ -30627,136 +23578,6 @@ package:
     sha256: f5818ac1741aa91b43185989b35319e6dd819c7beab271fc2bb7fda4be089128
   category: notebooks
   optional: true
-- name: prometheus-cpp
-  version: 1.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libcurl: '>=8.10.1,<9.0a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-    libzlib: '>=1.3.1,<2.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
-  hash:
-    md5: a83f6a2fdc079e643237887a37460668
-    sha256: 013669433eb447548f21c3c6b16b2ed64356f726b5f77c1b39d5ba17a8a4b8bc
-  category: container
-  optional: true
-- name: prometheus-cpp
-  version: 1.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libcurl: '>=8.10.1,<9.0a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-    libzlib: '>=1.3.1,<2.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
-  hash:
-    md5: a83f6a2fdc079e643237887a37460668
-    sha256: 013669433eb447548f21c3c6b16b2ed64356f726b5f77c1b39d5ba17a8a4b8bc
-  category: notebooks
-  optional: true
-- name: prometheus-cpp
-  version: 1.3.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libcurl: '>=8.10.1,<9.0a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-    libzlib: '>=1.3.1,<2.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/prometheus-cpp-1.3.0-h7938499_0.conda
-  hash:
-    md5: 10f4301290e51c49979ff98d1bdf2556
-    sha256: 9350d7bbc3982a732ff13a7fd17b585509e3b7d0191ac7b810cc3224868e3648
-  category: container
-  optional: true
-- name: prometheus-cpp
-  version: 1.3.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libcurl: '>=8.10.1,<9.0a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-    libzlib: '>=1.3.1,<2.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/prometheus-cpp-1.3.0-h7938499_0.conda
-  hash:
-    md5: 10f4301290e51c49979ff98d1bdf2556
-    sha256: 9350d7bbc3982a732ff13a7fd17b585509e3b7d0191ac7b810cc3224868e3648
-  category: notebooks
-  optional: true
-- name: prometheus-cpp
-  version: 1.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcurl: '>=8.10.1,<9.0a0'
-    libcxx: '>=18'
-    libzlib: '>=1.3.1,<2.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/prometheus-cpp-1.3.0-h7802330_0.conda
-  hash:
-    md5: f36107fa2557e63421a46676371c4226
-    sha256: af754a477ee2681cb7d5d77c621bd590d25fe1caf16741841fc2d176815fc7de
-  category: container
-  optional: true
-- name: prometheus-cpp
-  version: 1.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcurl: '>=8.10.1,<9.0a0'
-    libcxx: '>=18'
-    libzlib: '>=1.3.1,<2.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/prometheus-cpp-1.3.0-h7802330_0.conda
-  hash:
-    md5: f36107fa2557e63421a46676371c4226
-    sha256: af754a477ee2681cb7d5d77c621bd590d25fe1caf16741841fc2d176815fc7de
-  category: notebooks
-  optional: true
-- name: prometheus-cpp
-  version: 1.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcurl: '>=8.10.1,<9.0a0'
-    libcxx: '>=18'
-    libzlib: '>=1.3.1,<2.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/prometheus-cpp-1.3.0-h0967b3e_0.conda
-  hash:
-    md5: 7172339b49c94275ba42fec3eaeda34f
-    sha256: 851a77ae1a8e90db9b9f3c4466abea7afb52713c3d98ceb0d37ba6ff27df2eff
-  category: container
-  optional: true
-- name: prometheus-cpp
-  version: 1.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcurl: '>=8.10.1,<9.0a0'
-    libcxx: '>=18'
-    libzlib: '>=1.3.1,<2.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/prometheus-cpp-1.3.0-h0967b3e_0.conda
-  hash:
-    md5: 7172339b49c94275ba42fec3eaeda34f
-    sha256: 851a77ae1a8e90db9b9f3c4466abea7afb52713c3d98ceb0d37ba6ff27df2eff
-  category: notebooks
-  optional: true
 - name: prometheus_client
   version: 0.25.0
   manager: conda
@@ -30854,211 +23675,211 @@ package:
   category: jupyter
   optional: true
 - name: prompt-toolkit
-  version: 3.0.52
+  version: 3.0.51
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   hash:
-    md5: edb16f14d920fb3faf17f5ce582942d6
-    sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+    md5: d17ae9db4dc594267181bd199bf9a551
+    sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   category: container
   optional: true
 - name: prompt-toolkit
-  version: 3.0.52
+  version: 3.0.51
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   hash:
-    md5: edb16f14d920fb3faf17f5ce582942d6
-    sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+    md5: d17ae9db4dc594267181bd199bf9a551
+    sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   category: jupyter
   optional: true
 - name: prompt-toolkit
-  version: 3.0.52
+  version: 3.0.51
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   hash:
-    md5: edb16f14d920fb3faf17f5ce582942d6
-    sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+    md5: d17ae9db4dc594267181bd199bf9a551
+    sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   category: notebooks
   optional: true
 - name: prompt-toolkit
-  version: 3.0.52
+  version: 3.0.51
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   hash:
-    md5: edb16f14d920fb3faf17f5ce582942d6
-    sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+    md5: d17ae9db4dc594267181bd199bf9a551
+    sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   category: tools
   optional: true
 - name: prompt-toolkit
-  version: 3.0.52
+  version: 3.0.51
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   hash:
-    md5: edb16f14d920fb3faf17f5ce582942d6
-    sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+    md5: d17ae9db4dc594267181bd199bf9a551
+    sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   category: container
   optional: true
 - name: prompt-toolkit
-  version: 3.0.52
+  version: 3.0.51
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   hash:
-    md5: edb16f14d920fb3faf17f5ce582942d6
-    sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+    md5: d17ae9db4dc594267181bd199bf9a551
+    sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   category: jupyter
   optional: true
 - name: prompt-toolkit
-  version: 3.0.52
+  version: 3.0.51
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   hash:
-    md5: edb16f14d920fb3faf17f5ce582942d6
-    sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+    md5: d17ae9db4dc594267181bd199bf9a551
+    sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   category: notebooks
   optional: true
 - name: prompt-toolkit
-  version: 3.0.52
+  version: 3.0.51
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   hash:
-    md5: edb16f14d920fb3faf17f5ce582942d6
-    sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+    md5: d17ae9db4dc594267181bd199bf9a551
+    sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   category: tools
   optional: true
 - name: prompt-toolkit
-  version: 3.0.52
+  version: 3.0.51
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   hash:
-    md5: edb16f14d920fb3faf17f5ce582942d6
-    sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+    md5: d17ae9db4dc594267181bd199bf9a551
+    sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   category: container
   optional: true
 - name: prompt-toolkit
-  version: 3.0.52
+  version: 3.0.51
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   hash:
-    md5: edb16f14d920fb3faf17f5ce582942d6
-    sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+    md5: d17ae9db4dc594267181bd199bf9a551
+    sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   category: jupyter
   optional: true
 - name: prompt-toolkit
-  version: 3.0.52
+  version: 3.0.51
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   hash:
-    md5: edb16f14d920fb3faf17f5ce582942d6
-    sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+    md5: d17ae9db4dc594267181bd199bf9a551
+    sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   category: notebooks
   optional: true
 - name: prompt-toolkit
-  version: 3.0.52
+  version: 3.0.51
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   hash:
-    md5: edb16f14d920fb3faf17f5ce582942d6
-    sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+    md5: d17ae9db4dc594267181bd199bf9a551
+    sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   category: tools
   optional: true
 - name: prompt-toolkit
-  version: 3.0.52
+  version: 3.0.51
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   hash:
-    md5: edb16f14d920fb3faf17f5ce582942d6
-    sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+    md5: d17ae9db4dc594267181bd199bf9a551
+    sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   category: container
   optional: true
 - name: prompt-toolkit
-  version: 3.0.52
+  version: 3.0.51
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   hash:
-    md5: edb16f14d920fb3faf17f5ce582942d6
-    sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+    md5: d17ae9db4dc594267181bd199bf9a551
+    sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   category: jupyter
   optional: true
 - name: prompt-toolkit
-  version: 3.0.52
+  version: 3.0.51
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   hash:
-    md5: edb16f14d920fb3faf17f5ce582942d6
-    sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+    md5: d17ae9db4dc594267181bd199bf9a551
+    sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   category: notebooks
   optional: true
 - name: prompt-toolkit
-  version: 3.0.52
+  version: 3.0.51
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   hash:
-    md5: edb16f14d920fb3faf17f5ce582942d6
-    sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+    md5: d17ae9db4dc594267181bd199bf9a551
+    sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   category: tools
   optional: true
 - name: psutil
@@ -31289,104 +24110,6 @@ package:
     sha256: 1d2a6039fb71d61134b1d6816202529f2f6286c83b59bc1491fd288f5c08046e
   category: tools
   optional: true
-- name: pthread-stubs
-  version: '0.4'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
-  hash:
-    md5: b3c17d95b5a10c6e64a21fa17573e70e
-    sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
-  category: container
-  optional: true
-- name: pthread-stubs
-  version: '0.4'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
-  hash:
-    md5: b3c17d95b5a10c6e64a21fa17573e70e
-    sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
-  category: notebooks
-  optional: true
-- name: pthread-stubs
-  version: '0.4'
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
-  hash:
-    md5: bb5a90c93e3bac3d5690acf76b4a6386
-    sha256: 977dfb0cb3935d748521dd80262fe7169ab82920afd38ed14b7fee2ea5ec01ba
-  category: container
-  optional: true
-- name: pthread-stubs
-  version: '0.4'
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
-  hash:
-    md5: bb5a90c93e3bac3d5690acf76b4a6386
-    sha256: 977dfb0cb3935d748521dd80262fe7169ab82920afd38ed14b7fee2ea5ec01ba
-  category: notebooks
-  optional: true
-- name: pthread-stubs
-  version: '0.4'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
-  hash:
-    md5: 8bcf980d2c6b17094961198284b8e862
-    sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
-  category: container
-  optional: true
-- name: pthread-stubs
-  version: '0.4'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
-  hash:
-    md5: 8bcf980d2c6b17094961198284b8e862
-    sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
-  category: notebooks
-  optional: true
-- name: pthread-stubs
-  version: '0.4'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
-  hash:
-    md5: 415816daf82e0b23a736a069a75e9da7
-    sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
-  category: container
-  optional: true
-- name: pthread-stubs
-  version: '0.4'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
-  hash:
-    md5: 415816daf82e0b23a736a069a75e9da7
-    sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
-  category: notebooks
-  optional: true
 - name: ptyprocess
   version: 0.7.0
   manager: conda
@@ -31770,296 +24493,6 @@ package:
     md5: 3bfdfb8dbcdc4af1ae3f9a8eb3948f04
     sha256: 71bd24600d14bb171a6321d523486f6a06f855e75e547fa0cb2a0953b02047f0
   category: tools
-  optional: true
-- name: pyarrow
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libarrow-acero: 24.0.0.*
-    libarrow-dataset: 24.0.0.*
-    libarrow-substrait: 24.0.0.*
-    libparquet: 24.0.0.*
-    pyarrow-core: 24.0.0
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-24.0.0-py313h78bf25f_0.conda
-  hash:
-    md5: c93f1ad82cb397a98d6cadb4a07572af
-    sha256: 096c8948fc4a0436dd1e32294f57be135819909a112978833bc749d43b14dd33
-  category: container
-  optional: true
-- name: pyarrow
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libarrow-acero: 24.0.0.*
-    libarrow-dataset: 24.0.0.*
-    libarrow-substrait: 24.0.0.*
-    libparquet: 24.0.0.*
-    pyarrow-core: 24.0.0
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-24.0.0-py313h78bf25f_0.conda
-  hash:
-    md5: c93f1ad82cb397a98d6cadb4a07572af
-    sha256: 096c8948fc4a0436dd1e32294f57be135819909a112978833bc749d43b14dd33
-  category: notebooks
-  optional: true
-- name: pyarrow
-  version: 24.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libarrow-acero: 24.0.0.*
-    libarrow-dataset: 24.0.0.*
-    libarrow-substrait: 24.0.0.*
-    libparquet: 24.0.0.*
-    pyarrow-core: 24.0.0
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-24.0.0-py313h1258fbd_0.conda
-  hash:
-    md5: afc908ddc88973102d90b5433927d28b
-    sha256: 651c7652a34740d53dff89269a36ce86aa056ea3f88659383b0f5aa568b4396d
-  category: container
-  optional: true
-- name: pyarrow
-  version: 24.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libarrow-acero: 24.0.0.*
-    libarrow-dataset: 24.0.0.*
-    libarrow-substrait: 24.0.0.*
-    libparquet: 24.0.0.*
-    pyarrow-core: 24.0.0
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-24.0.0-py313h1258fbd_0.conda
-  hash:
-    md5: afc908ddc88973102d90b5433927d28b
-    sha256: 651c7652a34740d53dff89269a36ce86aa056ea3f88659383b0f5aa568b4396d
-  category: notebooks
-  optional: true
-- name: pyarrow
-  version: 24.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libarrow-acero: 24.0.0.*
-    libarrow-dataset: 24.0.0.*
-    libarrow-substrait: 24.0.0.*
-    libparquet: 24.0.0.*
-    pyarrow-core: 24.0.0
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-24.0.0-py313habf4b1d_0.conda
-  hash:
-    md5: 5819bbd5712568c8b0721bf4bde54b16
-    sha256: fd37980663d743a15d1442f045480e6e67d703c57621acd18359da46c9dbabe0
-  category: container
-  optional: true
-- name: pyarrow
-  version: 24.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libarrow-acero: 24.0.0.*
-    libarrow-dataset: 24.0.0.*
-    libarrow-substrait: 24.0.0.*
-    libparquet: 24.0.0.*
-    pyarrow-core: 24.0.0
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-24.0.0-py313habf4b1d_0.conda
-  hash:
-    md5: 5819bbd5712568c8b0721bf4bde54b16
-    sha256: fd37980663d743a15d1442f045480e6e67d703c57621acd18359da46c9dbabe0
-  category: notebooks
-  optional: true
-- name: pyarrow
-  version: 24.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libarrow-acero: 24.0.0.*
-    libarrow-dataset: 24.0.0.*
-    libarrow-substrait: 24.0.0.*
-    libparquet: 24.0.0.*
-    pyarrow-core: 24.0.0
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-24.0.0-py313h39782a4_0.conda
-  hash:
-    md5: a341ffb196fb28e4ec4d35163715f359
-    sha256: 6ab666e0a675898c03c0510e2dc7ec5918469a8ad3e6ce16206060699fe58846
-  category: container
-  optional: true
-- name: pyarrow
-  version: 24.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libarrow-acero: 24.0.0.*
-    libarrow-dataset: 24.0.0.*
-    libarrow-substrait: 24.0.0.*
-    libparquet: 24.0.0.*
-    pyarrow-core: 24.0.0
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-24.0.0-py313h39782a4_0.conda
-  hash:
-    md5: a341ffb196fb28e4ec4d35163715f359
-    sha256: 6ab666e0a675898c03c0510e2dc7ec5918469a8ad3e6ce16206060699fe58846
-  category: notebooks
-  optional: true
-- name: pyarrow-core
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libarrow: 24.0.0.*
-    libarrow-compute: 24.0.0.*
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-24.0.0-py313h98bfbea_0_cpu.conda
-  hash:
-    md5: 4c7cc18a6d6d18557c18069af469a96c
-    sha256: feeb4ae83dffa8af4ee131279925e22e6969958f14342015f94d75cc196ef689
-  category: container
-  optional: true
-- name: pyarrow-core
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libarrow: 24.0.0.*
-    libarrow-compute: 24.0.0.*
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-24.0.0-py313h98bfbea_0_cpu.conda
-  hash:
-    md5: 4c7cc18a6d6d18557c18069af469a96c
-    sha256: feeb4ae83dffa8af4ee131279925e22e6969958f14342015f94d75cc196ef689
-  category: notebooks
-  optional: true
-- name: pyarrow-core
-  version: 24.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libarrow: 24.0.0.*
-    libarrow-compute: 24.0.0.*
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-core-24.0.0-py313hc35d149_0_cpu.conda
-  hash:
-    md5: d06e14bb31399c45dbe03bff874f39f2
-    sha256: 7b2df126c137f6f4ef8108cd45da83f6e90eda940a2cff3246ffe54c4434de73
-  category: container
-  optional: true
-- name: pyarrow-core
-  version: 24.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libarrow: 24.0.0.*
-    libarrow-compute: 24.0.0.*
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.2,<2.0a0'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-core-24.0.0-py313hc35d149_0_cpu.conda
-  hash:
-    md5: d06e14bb31399c45dbe03bff874f39f2
-    sha256: 7b2df126c137f6f4ef8108cd45da83f6e90eda940a2cff3246ffe54c4434de73
-  category: notebooks
-  optional: true
-- name: pyarrow-core
-  version: 24.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libarrow: 24.0.0.*
-    libarrow-compute: 24.0.0.*
-    libcxx: '>=21'
-    libzlib: '>=1.3.2,<2.0a0'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-24.0.0-py313h345cca6_0_cpu.conda
-  hash:
-    md5: cb204c3fc6b57d78fcf40da49ab74fd1
-    sha256: 1ecf72f1dcf55e819155d4227597e25805aad4798ba06bfb526d4292e398cb71
-  category: container
-  optional: true
-- name: pyarrow-core
-  version: 24.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libarrow: 24.0.0.*
-    libarrow-compute: 24.0.0.*
-    libcxx: '>=21'
-    libzlib: '>=1.3.2,<2.0a0'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-24.0.0-py313h345cca6_0_cpu.conda
-  hash:
-    md5: cb204c3fc6b57d78fcf40da49ab74fd1
-    sha256: 1ecf72f1dcf55e819155d4227597e25805aad4798ba06bfb526d4292e398cb71
-  category: notebooks
-  optional: true
-- name: pyarrow-core
-  version: 24.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libarrow: 24.0.0.*
-    libarrow-compute: 24.0.0.*
-    libcxx: '>=21'
-    libzlib: '>=1.3.2,<2.0a0'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-24.0.0-py313h23b330d_0_cpu.conda
-  hash:
-    md5: ded47b8ff6e483c35d4aa92ed94c159c
-    sha256: 99645c5c6e8af3ad94292516376a84f0b001cfeb2167564d6988f9e2176e506f
-  category: container
-  optional: true
-- name: pyarrow-core
-  version: 24.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libarrow: 24.0.0.*
-    libarrow-compute: 24.0.0.*
-    libcxx: '>=21'
-    libzlib: '>=1.3.2,<2.0a0'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-24.0.0-py313h23b330d_0_cpu.conda
-  hash:
-    md5: ded47b8ff6e483c35d4aa92ed94c159c
-    sha256: 99645c5c6e8af3ad94292516376a84f0b001cfeb2167564d6988f9e2176e506f
-  category: notebooks
   optional: true
 - name: pybind11
   version: 3.0.3
@@ -32080,7 +24513,7 @@ package:
   platform: linux-aarch64
   dependencies:
     pybind11-global: ==3.0.3
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.3-pyhfe8187e_0.conda
   hash:
     md5: e0f4549ccb507d4af8ed5c5345210673
@@ -32093,7 +24526,7 @@ package:
   platform: osx-64
   dependencies:
     pybind11-global: ==3.0.3
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.3-pyhfe8187e_0.conda
   hash:
     md5: e0f4549ccb507d4af8ed5c5345210673
@@ -32106,7 +24539,7 @@ package:
   platform: osx-arm64
   dependencies:
     pybind11-global: ==3.0.3
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.3-pyhfe8187e_0.conda
   hash:
     md5: e0f4549ccb507d4af8ed5c5345210673
@@ -32176,7 +24609,7 @@ package:
   platform: linux-aarch64
   dependencies:
     __unix: ''
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.3-pyh648e204_0.conda
   hash:
     md5: 7fdc3e18c14b862ae5f064c1ea8e2636
@@ -32189,7 +24622,7 @@ package:
   platform: osx-64
   dependencies:
     __unix: ''
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.3-pyh648e204_0.conda
   hash:
     md5: 7fdc3e18c14b862ae5f064c1ea8e2636
@@ -32202,7 +24635,7 @@ package:
   platform: osx-arm64
   dependencies:
     __unix: ''
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.3-pyh648e204_0.conda
   hash:
     md5: 7fdc3e18c14b862ae5f064c1ea8e2636
@@ -32250,7 +24683,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
   hash:
     md5: 9c5491066224083c41b6d5635ed7107b
@@ -32262,7 +24695,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
   hash:
     md5: 9c5491066224083c41b6d5635ed7107b
@@ -32274,7 +24707,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
   hash:
     md5: 9c5491066224083c41b6d5635ed7107b
@@ -32286,7 +24719,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
   hash:
     md5: 9c5491066224083c41b6d5635ed7107b
@@ -32298,7 +24731,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
   hash:
     md5: 9c5491066224083c41b6d5635ed7107b
@@ -32310,7 +24743,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
   hash:
     md5: 9c5491066224083c41b6d5635ed7107b
@@ -32322,7 +24755,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
   hash:
     md5: 9c5491066224083c41b6d5635ed7107b
@@ -32334,7 +24767,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
   hash:
     md5: 9c5491066224083c41b6d5635ed7107b
@@ -32346,7 +24779,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
   hash:
     md5: 9c5491066224083c41b6d5635ed7107b
@@ -32392,7 +24825,7 @@ package:
   dependencies:
     annotated-types: '>=0.6.0'
     pydantic-core: 2.46.4
-    python: ''
+    python: '>=3.10'
     typing-inspection: '>=0.4.2'
     typing_extensions: '>=4.14.1'
   url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
@@ -32408,7 +24841,7 @@ package:
   dependencies:
     annotated-types: '>=0.6.0'
     pydantic-core: 2.46.4
-    python: ''
+    python: '>=3.10'
     typing-inspection: '>=0.4.2'
     typing_extensions: '>=4.14.1'
   url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
@@ -32424,7 +24857,7 @@ package:
   dependencies:
     annotated-types: '>=0.6.0'
     pydantic-core: 2.46.4
-    python: ''
+    python: '>=3.10'
     typing-inspection: '>=0.4.2'
     typing_extensions: '>=4.14.1'
   url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
@@ -32440,7 +24873,7 @@ package:
   dependencies:
     annotated-types: '>=0.6.0'
     pydantic-core: 2.46.4
-    python: ''
+    python: '>=3.10'
     typing-inspection: '>=0.4.2'
     typing_extensions: '>=4.14.1'
   url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
@@ -32456,7 +24889,7 @@ package:
   dependencies:
     annotated-types: '>=0.6.0'
     pydantic-core: 2.46.4
-    python: ''
+    python: '>=3.10'
     typing-inspection: '>=0.4.2'
     typing_extensions: '>=4.14.1'
   url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
@@ -32472,7 +24905,7 @@ package:
   dependencies:
     annotated-types: '>=0.6.0'
     pydantic-core: 2.46.4
-    python: ''
+    python: '>=3.10'
     typing-inspection: '>=0.4.2'
     typing_extensions: '>=4.14.1'
   url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
@@ -32795,79 +25228,6 @@ package:
     sha256: cf70b2f5ad9ae472b71235e5c8a736c9316df3705746de419b59d442e8348e86
   category: tools
   optional: true
-- name: pyinterp
-  version: 2026.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    dask: '*'
-    libgcc: '>=15'
-    libstdcxx: '>=15'
-    openblas: '*'
-    python: ''
-    python_abi: 3.13.*
-    xarray: '>=0.13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyinterp-2026.6.0-openblas_py313h29d7626_2.conda
-  hash:
-    md5: ebadb0532033486b6188b76f009cae77
-    sha256: b3c6901b299a4479b1c9f6b56626f67cae4c9d6aaa40458abfb67905e24c9d42
-  category: notebooks
-  optional: true
-- name: pyinterp
-  version: 2026.6.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    dask: '*'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    openblas: '*'
-    python: 3.13.*
-    python_abi: 3.13.*
-    xarray: '>=0.13'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pyinterp-2026.6.0-openblas_py313h7162799_2.conda
-  hash:
-    md5: ef86313f82d4982ac353a28a48d73cce
-    sha256: 7d2d20040fe939bb796f29a21ef1ef80ab390ded2a7f998d954017e94da4dc73
-  category: notebooks
-  optional: true
-- name: pyinterp
-  version: 2026.6.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    blas: '*'
-    dask: '*'
-    libcxx: '>=21'
-    python: ''
-    python_abi: 3.13.*
-    xarray: '>=0.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyinterp-2026.6.0-accelerate_py313hb6fc789_2.conda
-  hash:
-    md5: cceef4e2792cc6fd350dc997bc03de70
-    sha256: 1dd24af050edbb2ff817106d3c6fde84b45950be95c3d304d3f9dc3dbed49fd5
-  category: notebooks
-  optional: true
-- name: pyinterp
-  version: 2026.6.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    blas: '*'
-    dask: '*'
-    libcxx: '>=21'
-    python: 3.13.*
-    python_abi: 3.13.*
-    xarray: '>=0.13'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyinterp-2026.6.0-accelerate_py313h8e5c01a_2.conda
-  hash:
-    md5: b4beec5667b474b0b1b847763d6d0736
-    sha256: b47fea48409757c237f4fdf8d3490abe23b5f20511e9b790283f50ca0aeaf3ce
-  category: notebooks
-  optional: true
 - name: pyjwt
   version: 2.13.0
   manager: conda
@@ -32886,7 +25246,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.13.0-pyhcf101f3_0.conda
   hash:
@@ -32899,7 +25259,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.13.0-pyhcf101f3_0.conda
   hash:
@@ -32912,7 +25272,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.13.0-pyhcf101f3_0.conda
   hash:
@@ -32921,35 +25281,35 @@ package:
   category: container
   optional: true
 - name: pyobjc-core
-  version: '12.1'
+  version: 12.2.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libffi: '>=3.5.2,<3.6.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py313h07bcf3a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.2.1-py313h4cf37f9_0.conda
   hash:
-    md5: 6a2c3a617a70f97ca53b7b88461b1c27
-    sha256: 1e0edd34b804e20ba064dcebcfce3066d841ec812f29ed65902da7192af617d1
+    md5: 8e5d3f1d235bcc6e441b13d360de01fb
+    sha256: a24d8cf36794b9dab70e7760cd13a8502e0a8bab616727888fdab2e81300bfcf
   category: container
   optional: true
 - name: pyobjc-core
-  version: '12.1'
+  version: 12.2.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libffi: '>=3.5.2,<3.6.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py313h07bcf3a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.2.1-py313h4cf37f9_0.conda
   hash:
-    md5: 6a2c3a617a70f97ca53b7b88461b1c27
-    sha256: 1e0edd34b804e20ba064dcebcfce3066d841ec812f29ed65902da7192af617d1
+    md5: 8e5d3f1d235bcc6e441b13d360de01fb
+    sha256: a24d8cf36794b9dab70e7760cd13a8502e0a8bab616727888fdab2e81300bfcf
   category: jupyter
   optional: true
 - name: pyobjc-core
@@ -32985,35 +25345,35 @@ package:
   category: jupyter
   optional: true
 - name: pyobjc-framework-cocoa
-  version: '12.1'
+  version: 12.2.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libffi: '>=3.5.2,<3.6.0a0'
-    pyobjc-core: 12.1.*
+    pyobjc-core: 12.2.1.*
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py313hf669bc3_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.2.1-py313hc6ffd0f_0.conda
   hash:
-    md5: 628b5ad83d6140fe4bfa937e2f357ed7
-    sha256: 4761b8448bb9ecfcd9636a506104e6474e0f4cb73d108f2088997702ae984a00
+    md5: 77b02c902165e77a18092f192003bd89
+    sha256: 5ef23f4e7a3a673f7c5099c964f54322c0fb3653cefe51a3359c2e13734686e9
   category: container
   optional: true
 - name: pyobjc-framework-cocoa
-  version: '12.1'
+  version: 12.2.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libffi: '>=3.5.2,<3.6.0a0'
-    pyobjc-core: 12.1.*
+    pyobjc-core: 12.2.1.*
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py313hf669bc3_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.2.1-py313hc6ffd0f_0.conda
   hash:
-    md5: 628b5ad83d6140fe4bfa937e2f357ed7
-    sha256: 4761b8448bb9ecfcd9636a506104e6474e0f4cb73d108f2088997702ae984a00
+    md5: 77b02c902165e77a18092f192003bd89
+    sha256: 5ef23f4e7a3a673f7c5099c964f54322c0fb3653cefe51a3359c2e13734686e9
   category: jupyter
   optional: true
 - name: pyobjc-framework-cocoa
@@ -33326,6 +25686,7 @@ package:
     libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.6,<7.0a0'
     openssl: '>=3.5.7,<4.0a0'
+    pip: ''
     python_abi: 3.13.*
     readline: '>=8.3,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
@@ -33353,6 +25714,7 @@ package:
     libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.6,<7.0a0'
     openssl: '>=3.5.7,<4.0a0'
+    pip: ''
     python_abi: 3.13.*
     readline: '>=8.3,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
@@ -33378,6 +25740,7 @@ package:
     libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.6,<7.0a0'
     openssl: '>=3.5.7,<4.0a0'
+    pip: ''
     python_abi: 3.13.*
     readline: '>=8.3,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
@@ -33403,6 +25766,7 @@ package:
     libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.6,<7.0a0'
     openssl: '>=3.5.7,<4.0a0'
+    pip: ''
     python_abi: 3.13.*
     readline: '>=8.3,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
@@ -33439,7 +25803,7 @@ package:
     importlib-metadata: '>=4.6'
     packaging: '>=24.0'
     pyproject_hooks: ''
-    python: ''
+    python: '>=3.10'
     tomli: '>=1.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/python-build-1.5.0-pyhc364b38_0.conda
   hash:
@@ -33456,7 +25820,7 @@ package:
     importlib-metadata: '>=4.6'
     packaging: '>=24.0'
     pyproject_hooks: ''
-    python: ''
+    python: '>=3.10'
     tomli: '>=1.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/python-build-1.5.0-pyhc364b38_0.conda
   hash:
@@ -33473,7 +25837,7 @@ package:
     importlib-metadata: '>=4.6'
     packaging: '>=24.0'
     pyproject_hooks: ''
-    python: ''
+    python: '>=3.10'
     tomli: '>=1.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/python-build-1.5.0-pyhc364b38_0.conda
   hash:
@@ -33482,211 +25846,211 @@ package:
   category: tools
   optional: true
 - name: python-dateutil
-  version: 2.9.0.post0
+  version: 2.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
+    python: '>=3.7'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: container
   optional: true
 - name: python-dateutil
-  version: 2.9.0.post0
+  version: 2.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
+    python: '>=3.7'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: jupyter
   optional: true
 - name: python-dateutil
-  version: 2.9.0.post0
+  version: 2.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
+    python: '>=3.7'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: notebooks
   optional: true
 - name: python-dateutil
-  version: 2.9.0.post0
+  version: 2.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
+    python: '>=3.7'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: tools
   optional: true
 - name: python-dateutil
-  version: 2.9.0.post0
+  version: 2.9.0
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.7'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: container
   optional: true
 - name: python-dateutil
-  version: 2.9.0.post0
+  version: 2.9.0
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.7'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: jupyter
   optional: true
 - name: python-dateutil
-  version: 2.9.0.post0
+  version: 2.9.0
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.7'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: notebooks
   optional: true
 - name: python-dateutil
-  version: 2.9.0.post0
+  version: 2.9.0
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.7'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: tools
   optional: true
 - name: python-dateutil
-  version: 2.9.0.post0
+  version: 2.9.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.7'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: container
   optional: true
 - name: python-dateutil
-  version: 2.9.0.post0
+  version: 2.9.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.7'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: jupyter
   optional: true
 - name: python-dateutil
-  version: 2.9.0.post0
+  version: 2.9.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.7'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: notebooks
   optional: true
 - name: python-dateutil
-  version: 2.9.0.post0
+  version: 2.9.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.7'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: tools
   optional: true
 - name: python-dateutil
-  version: 2.9.0.post0
+  version: 2.9.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.7'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: container
   optional: true
 - name: python-dateutil
-  version: 2.9.0.post0
+  version: 2.9.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.7'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: jupyter
   optional: true
 - name: python-dateutil
-  version: 2.9.0.post0
+  version: 2.9.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.7'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: notebooks
   optional: true
 - name: python-dateutil
-  version: 2.9.0.post0
+  version: 2.9.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.7'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: tools
   optional: true
 - name: python-fastjsonschema
@@ -33730,7 +26094,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
   hash:
     md5: 23029aae904a2ba587daba708208012f
@@ -33742,7 +26106,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
   hash:
     md5: 23029aae904a2ba587daba708208012f
@@ -33754,7 +26118,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
   hash:
     md5: 23029aae904a2ba587daba708208012f
@@ -33766,7 +26130,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
   hash:
     md5: 23029aae904a2ba587daba708208012f
@@ -33778,7 +26142,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
   hash:
     md5: 23029aae904a2ba587daba708208012f
@@ -33790,7 +26154,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
   hash:
     md5: 23029aae904a2ba587daba708208012f
@@ -33802,7 +26166,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
   hash:
     md5: 23029aae904a2ba587daba708208012f
@@ -33814,7 +26178,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
   hash:
     md5: 23029aae904a2ba587daba708208012f
@@ -33826,7 +26190,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
   hash:
     md5: 23029aae904a2ba587daba708208012f
@@ -34430,7 +26794,7 @@ package:
   category: main
   optional: false
 - name: pytorch
-  version: 2.12.0
+  version: 2.12.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -34440,16 +26804,16 @@ package:
     fmt: '>=12.1.0,<12.2.0a0'
     fsspec: ''
     jinja2: ''
-    libabseil: '>=20260107.1,<20260108.0a0'
+    libabseil: '>=20260526.0,<20260527.0a0'
     libblas: '*'
     libcblas: '>=3.11.0,<4.0a0'
     libgcc: '>=14'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
+    libprotobuf: '>=7.35.1,<7.35.2.0a0'
     libstdcxx: '>=14'
-    libtorch: 2.12.0
+    libtorch: 2.12.1
     libuv: '>=1.52.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    llvm-openmp: '>=22.1.7'
+    llvm-openmp: '>=22.1.8'
     mkl: '>=2026.0.0,<2027.0a0'
     networkx: ''
     numpy: '>=1.23,<3'
@@ -34463,14 +26827,14 @@ package:
     sleef: '>=3.9.0,<4.0a0'
     sympy: '>=1.13.3'
     typing_extensions: '>=4.10.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.12.0-cpu_mkl_py313_h5a856d5_100.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.12.1-cpu_mkl_py313_h43789e0_100.conda
   hash:
-    md5: 3a9157a5a3df031c588be1cb574bfe26
-    sha256: 99a61f3672e5de446e8b43d1d4f135ce9435f449004f77f7cd2c70cb9d7b35e3
+    md5: d91acadfd48759c22d721cdbc941c14f
+    sha256: 0a922813c2f28601a0f35c0868af3b62d838ac2ac64b8980b7af0a548d0d08f7
   category: notebooks
   optional: true
 - name: pytorch
-  version: 2.12.0
+  version: 2.12.1
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -34479,16 +26843,16 @@ package:
     fmt: '>=12.1.0,<12.2.0a0'
     fsspec: ''
     jinja2: ''
-    libabseil: '>=20260107.1,<20260108.0a0'
+    libabseil: '>=20260526.0,<20260527.0a0'
     libcblas: '>=3.9.0,<4.0a0'
-    libgcc: '>=13'
+    libgcc: '>=14'
     liblapack: '>=3.9.0,<4.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libstdcxx: '>=13'
-    libtorch: 2.12.0
+    libprotobuf: '>=7.35.1,<7.35.2.0a0'
+    libstdcxx: '>=14'
+    libtorch: 2.12.1
     libuv: '>=1.52.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    llvm-openmp: '>=22.1.7'
+    llvm-openmp: '>=22.1.8'
     networkx: ''
     nomkl: ''
     numpy: '>=1.23,<3'
@@ -34502,10 +26866,10 @@ package:
     sleef: '>=3.9.0,<4.0a0'
     sympy: '>=1.13.3'
     typing_extensions: '>=4.10.0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pytorch-2.12.0-cpu_generic_py313_h08544dd_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pytorch-2.12.1-cpu_generic_py313_hfc3042b_0.conda
   hash:
-    md5: 722c7376920382061f53cee90222d0e8
-    sha256: 3457f258aab96ad60689063701e7c76f94db9744ce8348b23a72090bb343af52
+    md5: 04fa420b97562bfabdd375984b145735
+    sha256: e6c6bd6b8bcd67d93b597c0267353d0313645317777745dfcd3d05fbe17b3a7f
   category: notebooks
   optional: true
 - name: pytorch
@@ -34519,16 +26883,16 @@ package:
     fsspec: ''
     jinja2: ''
     libabseil: '>=20260107.1,<20260108.0a0'
+    libblas: '*'
     libcblas: '>=3.9.0,<4.0a0'
     libcxx: '>=19'
-    liblapack: '>=3.9.0,<4.0a0'
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
     libtorch: 2.12.0
     libuv: '>=1.52.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     llvm-openmp: '>=19.1.7'
+    mkl: '>=2023.2.0,<2024.0a0'
     networkx: ''
-    nomkl: ''
     numpy: '>=1.23,<3'
     onednn: '>=3.12,<4.0a0'
     optree: '>=0.13.0'
@@ -34540,10 +26904,10 @@ package:
     sleef: '>=3.9.0,<4.0a0'
     sympy: '>=1.13.3'
     typing_extensions: '>=4.10.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pytorch-2.12.0-cpu_generic_py313_hb047559_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pytorch-2.12.0-cpu_mkl_py313_hd931bd6_100.conda
   hash:
-    md5: 5f92708b016a9d870fe3682627a704ff
-    sha256: 038c18652d748b442e072fd33da614751fd461d978f850393acc1924615ace8b
+    md5: 928054a4d4e30983f777ef087a05f60d
+    sha256: 13d99d932a9ca64675629d38fe82cb48a4004dd5bb5e1936ff3b91fe569796cf
   category: notebooks
   optional: true
 - name: pytorch
@@ -35035,102 +27399,6 @@ package:
     sha256: 086cc67ec57afb7c9c09b5e09e7356b536b5b1af6c2e97117dc022cd22f0d472
   category: tools
   optional: true
-- name: re2
-  version: 2025.11.05
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libre2-11: 2025.11.05
-  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_1.conda
-  hash:
-    md5: 66a715bc01c77d43aca1f9fcb13dde3c
-    sha256: 3fc684b81631348540e9a42f6768b871dfeab532d3f47d5c341f1f83e2a2b2b2
-  category: container
-  optional: true
-- name: re2
-  version: 2025.11.05
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libre2-11: 2025.11.05
-  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_1.conda
-  hash:
-    md5: 66a715bc01c77d43aca1f9fcb13dde3c
-    sha256: 3fc684b81631348540e9a42f6768b871dfeab532d3f47d5c341f1f83e2a2b2b2
-  category: notebooks
-  optional: true
-- name: re2
-  version: 2025.11.05
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libre2-11: 2025.11.05
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/re2-2025.11.05-he0da282_1.conda
-  hash:
-    md5: 19c3c9412a4a46965c3a057eeefecbef
-    sha256: 6839b3f4cbd900e974f62b069f4231d3f7a2c74731ef8fb0b4a858e66f7187ae
-  category: container
-  optional: true
-- name: re2
-  version: 2025.11.05
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libre2-11: 2025.11.05
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/re2-2025.11.05-he0da282_1.conda
-  hash:
-    md5: 19c3c9412a4a46965c3a057eeefecbef
-    sha256: 6839b3f4cbd900e974f62b069f4231d3f7a2c74731ef8fb0b4a858e66f7187ae
-  category: notebooks
-  optional: true
-- name: re2
-  version: 2025.11.05
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libre2-11: 2025.11.05
-  url: https://conda.anaconda.org/conda-forge/osx-64/re2-2025.11.05-h77e0585_1.conda
-  hash:
-    md5: b2cc31f114e4487d24e5617e62a24017
-    sha256: 1aeb9a9554cc719d454ad6158afbb0c249973fa4ee1d782d7e40cbec1de9b061
-  category: container
-  optional: true
-- name: re2
-  version: 2025.11.05
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libre2-11: 2025.11.05
-  url: https://conda.anaconda.org/conda-forge/osx-64/re2-2025.11.05-h77e0585_1.conda
-  hash:
-    md5: b2cc31f114e4487d24e5617e62a24017
-    sha256: 1aeb9a9554cc719d454ad6158afbb0c249973fa4ee1d782d7e40cbec1de9b061
-  category: notebooks
-  optional: true
-- name: re2
-  version: 2025.11.05
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libre2-11: 2025.11.05
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2025.11.05-ha480c28_1.conda
-  hash:
-    md5: a1ff22f664b0affa3de712749ccfbf04
-    sha256: 5bab972e8f2bff1b5b3574ffec8ecb89f7937578bd107584ed3fde507ff132f9
-  category: container
-  optional: true
-- name: re2
-  version: 2025.11.05
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libre2-11: 2025.11.05
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2025.11.05-ha480c28_1.conda
-  hash:
-    md5: a1ff22f664b0affa3de712749ccfbf04
-    sha256: 5bab972e8f2bff1b5b3574ffec8ecb89f7937578bd107584ed3fde507ff132f9
-  category: notebooks
-  optional: true
 - name: readline
   version: '8.3'
   manager: conda
@@ -35235,7 +27503,7 @@ package:
   platform: linux-aarch64
   dependencies:
     attrs: '>=22.2.0'
-    python: ''
+    python: '>=3.10'
     rpds-py: '>=0.7.0'
     typing_extensions: '>=4.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
@@ -35250,7 +27518,7 @@ package:
   platform: linux-aarch64
   dependencies:
     attrs: '>=22.2.0'
-    python: ''
+    python: '>=3.10'
     rpds-py: '>=0.7.0'
     typing_extensions: '>=4.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
@@ -35265,7 +27533,7 @@ package:
   platform: linux-aarch64
   dependencies:
     attrs: '>=22.2.0'
-    python: ''
+    python: '>=3.10'
     rpds-py: '>=0.7.0'
     typing_extensions: '>=4.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
@@ -35280,7 +27548,7 @@ package:
   platform: osx-64
   dependencies:
     attrs: '>=22.2.0'
-    python: ''
+    python: '>=3.10'
     rpds-py: '>=0.7.0'
     typing_extensions: '>=4.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
@@ -35295,7 +27563,7 @@ package:
   platform: osx-64
   dependencies:
     attrs: '>=22.2.0'
-    python: ''
+    python: '>=3.10'
     rpds-py: '>=0.7.0'
     typing_extensions: '>=4.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
@@ -35310,7 +27578,7 @@ package:
   platform: osx-64
   dependencies:
     attrs: '>=22.2.0'
-    python: ''
+    python: '>=3.10'
     rpds-py: '>=0.7.0'
     typing_extensions: '>=4.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
@@ -35325,7 +27593,7 @@ package:
   platform: osx-arm64
   dependencies:
     attrs: '>=22.2.0'
-    python: ''
+    python: '>=3.10'
     rpds-py: '>=0.7.0'
     typing_extensions: '>=4.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
@@ -35340,7 +27608,7 @@ package:
   platform: osx-arm64
   dependencies:
     attrs: '>=22.2.0'
-    python: ''
+    python: '>=3.10'
     rpds-py: '>=0.7.0'
     typing_extensions: '>=4.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
@@ -35355,7 +27623,7 @@ package:
   platform: osx-arm64
   dependencies:
     attrs: '>=22.2.0'
-    python: ''
+    python: '>=3.10'
     rpds-py: '>=0.7.0'
     typing_extensions: '>=4.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
@@ -35436,7 +27704,7 @@ package:
     certifi: '>=2023.5.7'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
-    python: ''
+    python: '>=3.10'
     urllib3: '>=1.26,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
   hash:
@@ -35452,7 +27720,7 @@ package:
     certifi: '>=2023.5.7'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
-    python: ''
+    python: '>=3.10'
     urllib3: '>=1.26,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
   hash:
@@ -35468,7 +27736,7 @@ package:
     certifi: '>=2023.5.7'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
-    python: ''
+    python: '>=3.10'
     urllib3: '>=1.26,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
   hash:
@@ -35484,7 +27752,7 @@ package:
     certifi: '>=2023.5.7'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
-    python: ''
+    python: '>=3.10'
     urllib3: '>=1.26,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
   hash:
@@ -35500,7 +27768,7 @@ package:
     certifi: '>=2023.5.7'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
-    python: ''
+    python: '>=3.10'
     urllib3: '>=1.26,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
   hash:
@@ -35516,7 +27784,7 @@ package:
     certifi: '>=2023.5.7'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
-    python: ''
+    python: '>=3.10'
     urllib3: '>=1.26,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
   hash:
@@ -35532,7 +27800,7 @@ package:
     certifi: '>=2023.5.7'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
-    python: ''
+    python: '>=3.10'
     urllib3: '>=1.26,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
   hash:
@@ -35548,7 +27816,7 @@ package:
     certifi: '>=2023.5.7'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
-    python: ''
+    python: '>=3.10'
     urllib3: '>=1.26,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
   hash:
@@ -35564,7 +27832,7 @@ package:
     certifi: '>=2023.5.7'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
-    python: ''
+    python: '>=3.10'
     urllib3: '>=1.26,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
   hash:
@@ -35580,7 +27848,7 @@ package:
     certifi: '>=2023.5.7'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
-    python: ''
+    python: '>=3.10'
     urllib3: '>=1.26,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
   hash:
@@ -35596,7 +27864,7 @@ package:
     certifi: '>=2023.5.7'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
-    python: ''
+    python: '>=3.10'
     urllib3: '>=1.26,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
   hash:
@@ -35612,7 +27880,7 @@ package:
     certifi: '>=2023.5.7'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
-    python: ''
+    python: '>=3.10'
     urllib3: '>=1.26,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
   hash:
@@ -35904,7 +28172,7 @@ package:
   platform: linux-aarch64
   dependencies:
     lark: '>=1.2.2'
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
   hash:
     md5: 7234f99325263a5af6d4cd195035e8f2
@@ -35917,7 +28185,7 @@ package:
   platform: linux-aarch64
   dependencies:
     lark: '>=1.2.2'
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
   hash:
     md5: 7234f99325263a5af6d4cd195035e8f2
@@ -35930,7 +28198,7 @@ package:
   platform: osx-64
   dependencies:
     lark: '>=1.2.2'
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
   hash:
     md5: 7234f99325263a5af6d4cd195035e8f2
@@ -35943,7 +28211,7 @@ package:
   platform: osx-64
   dependencies:
     lark: '>=1.2.2'
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
   hash:
     md5: 7234f99325263a5af6d4cd195035e8f2
@@ -35956,7 +28224,7 @@ package:
   platform: osx-arm64
   dependencies:
     lark: '>=1.2.2'
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
   hash:
     md5: 7234f99325263a5af6d4cd195035e8f2
@@ -35969,7 +28237,7 @@ package:
   platform: osx-arm64
   dependencies:
     lark: '>=1.2.2'
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
   hash:
     md5: 7234f99325263a5af6d4cd195035e8f2
@@ -36158,6 +28426,19 @@ package:
   hash:
     md5: 06ad944772941d5dae1e0d09848d8e49
     sha256: b48bebe297a63ae60f52e50be328262e880702db4d9b4e86731473ada459c2a1
+  category: container
+  optional: true
+- name: ruamel.yaml
+  version: 0.19.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: ''
+    ruamel.yaml.clib: '>=0.2.15'
+  url: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+  hash:
+    md5: 06ad944772941d5dae1e0d09848d8e49
+    sha256: b48bebe297a63ae60f52e50be328262e880702db4d9b4e86731473ada459c2a1
   category: tools
   optional: true
 - name: ruamel.yaml
@@ -36165,7 +28446,20 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
+    ruamel.yaml.clib: '>=0.2.15'
+  url: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+  hash:
+    md5: 06ad944772941d5dae1e0d09848d8e49
+    sha256: b48bebe297a63ae60f52e50be328262e880702db4d9b4e86731473ada459c2a1
+  category: container
+  optional: true
+- name: ruamel.yaml
+  version: 0.19.1
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    python: '>=3.10'
     ruamel.yaml.clib: '>=0.2.15'
   url: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
   hash:
@@ -36178,7 +28472,20 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
+    ruamel.yaml.clib: '>=0.2.15'
+  url: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+  hash:
+    md5: 06ad944772941d5dae1e0d09848d8e49
+    sha256: b48bebe297a63ae60f52e50be328262e880702db4d9b4e86731473ada459c2a1
+  category: container
+  optional: true
+- name: ruamel.yaml
+  version: 0.19.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.10'
     ruamel.yaml.clib: '>=0.2.15'
   url: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
   hash:
@@ -36191,13 +28498,41 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
+    ruamel.yaml.clib: '>=0.2.15'
+  url: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+  hash:
+    md5: 06ad944772941d5dae1e0d09848d8e49
+    sha256: b48bebe297a63ae60f52e50be328262e880702db4d9b4e86731473ada459c2a1
+  category: container
+  optional: true
+- name: ruamel.yaml
+  version: 0.19.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.10'
     ruamel.yaml.clib: '>=0.2.15'
   url: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
   hash:
     md5: 06ad944772941d5dae1e0d09848d8e49
     sha256: b48bebe297a63ae60f52e50be328262e880702db4d9b4e86731473ada459c2a1
   category: tools
+  optional: true
+- name: ruamel.yaml.clib
+  version: 0.2.15
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    python: ''
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py313h54dd161_1.conda
+  hash:
+    md5: ef8c7c9f4ea478806d9056bbc9c9c093
+    sha256: e7655f12e29add10ef6842ca7e06167fc326903f32b0a9e62f464afda4e0d3d1
+  category: container
   optional: true
 - name: ruamel.yaml.clib
   version: 0.2.15
@@ -36226,7 +28561,35 @@ package:
   hash:
     md5: c9b429b31dbd72e5fe526a2e74938302
     sha256: 5486ef35108064ba03dd7aaad48d2c31ba47318a0a8205757b28c65a435f010a
+  category: container
+  optional: true
+- name: ruamel.yaml.clib
+  version: 0.2.15
+  manager: conda
+  platform: linux-aarch64
+  dependencies:
+    libgcc: '>=14'
+    python: 3.13.*
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py313h62ef0ea_1.conda
+  hash:
+    md5: c9b429b31dbd72e5fe526a2e74938302
+    sha256: 5486ef35108064ba03dd7aaad48d2c31ba47318a0a8205757b28c65a435f010a
   category: tools
+  optional: true
+- name: ruamel.yaml.clib
+  version: 0.2.15
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    python: ''
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.15-py313h16366db_1.conda
+  hash:
+    md5: 846c1dd713142a49a08e917a92343f51
+    sha256: 0bcb752de3e034b43529fc41aec9bca95cf1d1b9ae741b9db7bccd980ef603ac
+  category: container
   optional: true
 - name: ruamel.yaml.clib
   version: 0.2.15
@@ -36254,60 +28617,74 @@ package:
   hash:
     md5: ccc49acbc9df82571383070bc4591c45
     sha256: d2050d1d9fb396bd8fb42758bcc6e5bf301c94856086be5411dfe21a0bb2da22
+  category: container
+  optional: true
+- name: ruamel.yaml.clib
+  version: 0.2.15
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    python: 3.13.*
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py313h6688731_1.conda
+  hash:
+    md5: ccc49acbc9df82571383070bc4591c45
+    sha256: d2050d1d9fb396bd8fb42758bcc6e5bf301c94856086be5411dfe21a0bb2da22
   category: tools
   optional: true
 - name: s2n
-  version: 1.7.4
+  version: 1.7.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.4-h92489ea_1.conda
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.2-hc5a330e_1.conda
   hash:
-    md5: a20feedf58ce5441b115cebf284a9a75
-    sha256: de0bb8c7526684c9927cc687d4d07abe09d023a3ec950cfcd61089b495e2e616
+    md5: 3f578c7d2b0bb52469340e4060d48d94
+    sha256: 856866fd519b812db3e092aba308248dd87b5c308186fcffe593f309373ae94c
   category: container
   optional: true
 - name: s2n
-  version: 1.7.4
+  version: 1.7.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.4-h92489ea_1.conda
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.2-hc5a330e_1.conda
   hash:
-    md5: a20feedf58ce5441b115cebf284a9a75
-    sha256: de0bb8c7526684c9927cc687d4d07abe09d023a3ec950cfcd61089b495e2e616
+    md5: 3f578c7d2b0bb52469340e4060d48d94
+    sha256: 856866fd519b812db3e092aba308248dd87b5c308186fcffe593f309373ae94c
   category: notebooks
   optional: true
 - name: s2n
-  version: 1.7.4
+  version: 1.7.2
   manager: conda
   platform: linux-aarch64
   dependencies:
     libgcc: '>=14'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.7.4-h5288e76_1.conda
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.7.2-h8d42d4d_1.conda
   hash:
-    md5: 5a4f2fbdea654d46e98c8922c178ce0b
-    sha256: 2123c7c025a0fd9ab0d46770524ef0e83c254c2a0af494e11230d613becbf87f
+    md5: 5d28f677274b1d4486b3228b6a48042e
+    sha256: e94791b9a06e0bfbcef5d4b98edcc672c5ceed246f82edc8e9e4a13dfa0d5657
   category: container
   optional: true
 - name: s2n
-  version: 1.7.4
+  version: 1.7.2
   manager: conda
   platform: linux-aarch64
   dependencies:
     libgcc: '>=14'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.7.4-h5288e76_1.conda
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.7.2-h8d42d4d_1.conda
   hash:
-    md5: 5a4f2fbdea654d46e98c8922c178ce0b
-    sha256: 2123c7c025a0fd9ab0d46770524ef0e83c254c2a0af494e11230d613becbf87f
+    md5: 5d28f677274b1d4486b3228b6a48042e
+    sha256: e94791b9a06e0bfbcef5d4b98edcc672c5ceed246f82edc8e9e4a13dfa0d5657
   category: notebooks
   optional: true
 - name: secretstorage
@@ -36359,7 +28736,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
   hash:
     md5: 8e7be844ccb9706a999a337e056606ab
@@ -36371,7 +28748,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
   hash:
     md5: 8e7be844ccb9706a999a337e056606ab
@@ -36383,7 +28760,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
   hash:
     md5: 8e7be844ccb9706a999a337e056606ab
@@ -36422,7 +28799,7 @@ package:
   platform: linux-aarch64
   dependencies:
     __linux: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyha191276_1.conda
   hash:
     md5: 28eb91468df04f655a57bcfbb35fc5c5
@@ -36435,7 +28812,7 @@ package:
   platform: linux-aarch64
   dependencies:
     __linux: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyha191276_1.conda
   hash:
     md5: 28eb91468df04f655a57bcfbb35fc5c5
@@ -36449,7 +28826,7 @@ package:
   dependencies:
     __osx: ''
     pyobjc-framework-cocoa: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyh5552912_1.conda
   hash:
     md5: b70e2d44e6aa2beb69ba64206a16e4c6
@@ -36463,7 +28840,7 @@ package:
   dependencies:
     __osx: ''
     pyobjc-framework-cocoa: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyh5552912_1.conda
   hash:
     md5: b70e2d44e6aa2beb69ba64206a16e4c6
@@ -36477,7 +28854,7 @@ package:
   dependencies:
     __osx: ''
     pyobjc-framework-cocoa: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyh5552912_1.conda
   hash:
     md5: b70e2d44e6aa2beb69ba64206a16e4c6
@@ -36491,7 +28868,7 @@ package:
   dependencies:
     __osx: ''
     pyobjc-framework-cocoa: ''
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyh5552912_1.conda
   hash:
     md5: b70e2d44e6aa2beb69ba64206a16e4c6
@@ -36791,7 +29168,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   hash:
     md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -36803,7 +29180,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   hash:
     md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -36815,7 +29192,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   hash:
     md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -36827,7 +29204,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   hash:
     md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -36839,7 +29216,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   hash:
     md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -36851,7 +29228,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   hash:
     md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -36863,7 +29240,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   hash:
     md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -36875,7 +29252,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   hash:
     md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -36887,7 +29264,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   hash:
     md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -36899,7 +29276,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   hash:
     md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -36911,7 +29288,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   hash:
     md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -36923,7 +29300,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   hash:
     md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -37016,7 +29393,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhcf101f3_1.conda
   hash:
     md5: b899f1195be56d8215ed1973a8f409c3
@@ -37028,7 +29405,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhcf101f3_1.conda
   hash:
     md5: b899f1195be56d8215ed1973a8f409c3
@@ -37040,7 +29417,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhcf101f3_1.conda
   hash:
     md5: b899f1195be56d8215ed1973a8f409c3
@@ -37052,7 +29429,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhcf101f3_1.conda
   hash:
     md5: b899f1195be56d8215ed1973a8f409c3
@@ -37064,7 +29441,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhcf101f3_1.conda
   hash:
     md5: b899f1195be56d8215ed1973a8f409c3
@@ -37076,26 +29453,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhcf101f3_1.conda
   hash:
     md5: b899f1195be56d8215ed1973a8f409c3
     sha256: bc86861086db65c9b56dd6a1605755f41a9875b94fc3b69e137f686700d91aa1
   category: tools
-  optional: true
-- name: snappy
-  version: 1.2.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
-  hash:
-    md5: 98b6c9dc80eb87b2519b97bcf7e578dd
-    sha256: 48f3f6a76c34b2cfe80de9ce7f2283ecb55d5ed47367ba91e8bb8104e12b8f11
-  category: container
   optional: true
 - name: snappy
   version: 1.2.2
@@ -37122,19 +29485,6 @@ package:
   hash:
     md5: 3dec912091fb88614afa0af2712c1362
     sha256: a8a79c53852fb07286407907402caa5a96b6e22b518c4f010be40647f9ee3726
-  category: container
-  optional: true
-- name: snappy
-  version: 1.2.2
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.2.2-he774c54_1.conda
-  hash:
-    md5: 3dec912091fb88614afa0af2712c1362
-    sha256: a8a79c53852fb07286407907402caa5a96b6e22b518c4f010be40647f9ee3726
   category: notebooks
   optional: true
 - name: snappy
@@ -37148,33 +29498,7 @@ package:
   hash:
     md5: 2e993292ec18af5cd480932d448598cf
     sha256: 1525e6d8e2edf32dabfe2a8e2fc8bf2df81c5ef9f0b5374a3d4ccfa672bfd949
-  category: container
-  optional: true
-- name: snappy
-  version: 1.2.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.2-h01f5ddf_1.conda
-  hash:
-    md5: 2e993292ec18af5cd480932d448598cf
-    sha256: 1525e6d8e2edf32dabfe2a8e2fc8bf2df81c5ef9f0b5374a3d4ccfa672bfd949
   category: notebooks
-  optional: true
-- name: snappy
-  version: 1.2.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
-  hash:
-    md5: fca4a2222994acd7f691e57f94b750c5
-    sha256: cb9305ede19584115f43baecdf09a3866bfcd5bcca0d9e527bd76d9a1dbe2d8d
-  category: container
   optional: true
 - name: snappy
   version: 1.2.2
@@ -37284,102 +29608,6 @@ package:
     md5: 03fe290994c5e4ec17293cfb6bdce520
     sha256: dce518f45e24cd03f401cb0616917773159a210c19d601c5f2d4e0e5879d30ad
   category: jupyter
-  optional: true
-- name: sortedcontainers
-  version: 2.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 0401a17ae845fa72c7210e206ec5647d
-    sha256: d1e3e06b5cf26093047e63c8cc77b70d970411c5cbc0cb1fad461a8a8df599f7
-  category: container
-  optional: true
-- name: sortedcontainers
-  version: 2.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 0401a17ae845fa72c7210e206ec5647d
-    sha256: d1e3e06b5cf26093047e63c8cc77b70d970411c5cbc0cb1fad461a8a8df599f7
-  category: notebooks
-  optional: true
-- name: sortedcontainers
-  version: 2.4.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 0401a17ae845fa72c7210e206ec5647d
-    sha256: d1e3e06b5cf26093047e63c8cc77b70d970411c5cbc0cb1fad461a8a8df599f7
-  category: container
-  optional: true
-- name: sortedcontainers
-  version: 2.4.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 0401a17ae845fa72c7210e206ec5647d
-    sha256: d1e3e06b5cf26093047e63c8cc77b70d970411c5cbc0cb1fad461a8a8df599f7
-  category: notebooks
-  optional: true
-- name: sortedcontainers
-  version: 2.4.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 0401a17ae845fa72c7210e206ec5647d
-    sha256: d1e3e06b5cf26093047e63c8cc77b70d970411c5cbc0cb1fad461a8a8df599f7
-  category: container
-  optional: true
-- name: sortedcontainers
-  version: 2.4.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 0401a17ae845fa72c7210e206ec5647d
-    sha256: d1e3e06b5cf26093047e63c8cc77b70d970411c5cbc0cb1fad461a8a8df599f7
-  category: notebooks
-  optional: true
-- name: sortedcontainers
-  version: 2.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 0401a17ae845fa72c7210e206ec5647d
-    sha256: d1e3e06b5cf26093047e63c8cc77b70d970411c5cbc0cb1fad461a8a8df599f7
-  category: container
-  optional: true
-- name: sortedcontainers
-  version: 2.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 0401a17ae845fa72c7210e206ec5647d
-    sha256: d1e3e06b5cf26093047e63c8cc77b70d970411c5cbc0cb1fad461a8a8df599f7
-  category: notebooks
   optional: true
 - name: soupsieve
   version: 2.8.4
@@ -37667,10 +29895,10 @@ package:
     libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.6,<7.0a0'
     readline: '>=8.3,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.2-h04a0ce9_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.2-h04a0ce9_1.conda
   hash:
-    md5: 4085f6f50add20b9d01451e345e11809
-    sha256: 1743381e62402f16a303426bf27ea192054a15f70d3923a7bf2cd1c640a84358
+    md5: 7c683cb1ee6df789277df1dc0cc63111
+    sha256: e26c4cbcba43c2621f23e2df17abf8c823e93ef187796a1e352356b4d8aa807e
   category: notebooks
   optional: true
 - name: sqlite
@@ -37678,15 +29906,16 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
+    icu: '>=78.3,<79.0a0'
     libgcc: '>=14'
     libsqlite: 3.53.2
     libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.6,<7.0a0'
     readline: '>=8.3,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlite-3.53.2-he8854b5_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlite-3.53.2-hf1c7be2_1.conda
   hash:
-    md5: 1dca7787aa6b8461928f738d0bfc4596
-    sha256: 916bf3ce6f81df6dd7b31c12000d01af56c8f7058672cf9afc74c5e3c4089235
+    md5: 02abc4ed439c1c17c53c4a3a3c5e3423
+    sha256: adcb13f392e5933ebe0094aa16427a8ece5f8a01e968bc6bf40c16a7315ca2a6
   category: notebooks
   optional: true
 - name: sqlite
@@ -37699,10 +29928,10 @@ package:
     libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.6,<7.0a0'
     readline: '>=8.3,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.53.2-hd4d344e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.53.2-hd4d344e_1.conda
   hash:
-    md5: 86fbde90494b0235a3080bc34f8fa9ae
-    sha256: abeba58509c31e8c132c38f15bd4544ba8430b9b58365d411fd5ccf3721bdfcd
+    md5: 4e0271ec4bdb2a378312dbcf86688f54
+    sha256: 3418e26a97d65b47fc13c87e347cd3840477ebb519a95e150de023cd6612406e
   category: notebooks
   optional: true
 - name: sqlite
@@ -37711,14 +29940,15 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
     libsqlite: 3.53.2
     libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.6,<7.0a0'
     readline: '>=8.3,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.53.2-h85ec8f2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.53.2-h77b7338_1.conda
   hash:
-    md5: 1966e1b7f598b30cd746309ba483e541
-    sha256: 5d0a6544dcbbec6322c06a8ee994d6823916af35bbd5a0f8c35387869f1b5d76
+    md5: 725a35de8e373be31d2e1b5c7ef70a0a
+    sha256: ed6b5cbae69f919f092429fc53cb642a0743f317772337757531255f68ce89d6
   category: notebooks
   optional: true
 - name: stack_data
@@ -38055,100 +30285,32 @@ package:
     sha256: 30cb9355c2fefc20ff1a3d6566b9714d5614086a2524c07721fc344eb20515ae
   category: notebooks
   optional: true
-- name: tblib
-  version: 3.2.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.2.2-pyhcf101f3_0.conda
-  hash:
-    md5: f88bb644823094f436792f80fba3207e
-    sha256: 6b549360f687ee4d11bf85a6d6a276a30f9333df1857adb0fe785f0f8e9bcd60
-  category: container
-  optional: true
-- name: tblib
-  version: 3.2.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.2.2-pyhcf101f3_0.conda
-  hash:
-    md5: f88bb644823094f436792f80fba3207e
-    sha256: 6b549360f687ee4d11bf85a6d6a276a30f9333df1857adb0fe785f0f8e9bcd60
-  category: notebooks
-  optional: true
-- name: tblib
-  version: 3.2.2
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.2.2-pyhcf101f3_0.conda
-  hash:
-    md5: f88bb644823094f436792f80fba3207e
-    sha256: 6b549360f687ee4d11bf85a6d6a276a30f9333df1857adb0fe785f0f8e9bcd60
-  category: container
-  optional: true
-- name: tblib
-  version: 3.2.2
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.2.2-pyhcf101f3_0.conda
-  hash:
-    md5: f88bb644823094f436792f80fba3207e
-    sha256: 6b549360f687ee4d11bf85a6d6a276a30f9333df1857adb0fe785f0f8e9bcd60
-  category: notebooks
-  optional: true
-- name: tblib
-  version: 3.2.2
+- name: tbb
+  version: 2021.13.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.2.2-pyhcf101f3_0.conda
+    __osx: '>=11.0'
+    libcxx: '>=19'
+    libhwloc: '>=2.13.0,<2.13.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.13.0-hc1436ee_6.conda
   hash:
-    md5: f88bb644823094f436792f80fba3207e
-    sha256: 6b549360f687ee4d11bf85a6d6a276a30f9333df1857adb0fe785f0f8e9bcd60
+    md5: b781a4099393cffae4835ab4c07e664a
+    sha256: 7585c40ffd1b2346f31fd857a9882a4e5558e35d3f63640d925fe50a80bf06d6
   category: container
   optional: true
-- name: tblib
-  version: 3.2.2
+- name: tbb
+  version: 2021.13.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.2.2-pyhcf101f3_0.conda
+    __osx: '>=11.0'
+    libcxx: '>=19'
+    libhwloc: '>=2.13.0,<2.13.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.13.0-hc1436ee_6.conda
   hash:
-    md5: f88bb644823094f436792f80fba3207e
-    sha256: 6b549360f687ee4d11bf85a6d6a276a30f9333df1857adb0fe785f0f8e9bcd60
-  category: notebooks
-  optional: true
-- name: tblib
-  version: 3.2.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.2.2-pyhcf101f3_0.conda
-  hash:
-    md5: f88bb644823094f436792f80fba3207e
-    sha256: 6b549360f687ee4d11bf85a6d6a276a30f9333df1857adb0fe785f0f8e9bcd60
-  category: container
-  optional: true
-- name: tblib
-  version: 3.2.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.2.2-pyhcf101f3_0.conda
-  hash:
-    md5: f88bb644823094f436792f80fba3207e
-    sha256: 6b549360f687ee4d11bf85a6d6a276a30f9333df1857adb0fe785f0f8e9bcd60
+    md5: b781a4099393cffae4835ab4c07e664a
+    sha256: 7585c40ffd1b2346f31fd857a9882a4e5558e35d3f63640d925fe50a80bf06d6
   category: notebooks
   optional: true
 - name: terminado
@@ -38188,7 +30350,7 @@ package:
   dependencies:
     __unix: ''
     ptyprocess: ''
-    python: ''
+    python: '>=3.10'
     tornado: '>=6.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
   hash:
@@ -38203,7 +30365,7 @@ package:
   dependencies:
     __unix: ''
     ptyprocess: ''
-    python: ''
+    python: '>=3.10'
     tornado: '>=6.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
   hash:
@@ -38218,7 +30380,7 @@ package:
   dependencies:
     __unix: ''
     ptyprocess: ''
-    python: ''
+    python: '>=3.10'
     tornado: '>=6.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
   hash:
@@ -38233,7 +30395,7 @@ package:
   dependencies:
     __unix: ''
     ptyprocess: ''
-    python: ''
+    python: '>=3.10'
     tornado: '>=6.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
   hash:
@@ -38248,7 +30410,7 @@ package:
   dependencies:
     __unix: ''
     ptyprocess: ''
-    python: ''
+    python: '>=3.10'
     tornado: '>=6.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
   hash:
@@ -38263,7 +30425,7 @@ package:
   dependencies:
     __unix: ''
     ptyprocess: ''
-    python: ''
+    python: '>=3.10'
     tornado: '>=6.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
   hash:
@@ -38381,12 +30543,12 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
+    libgcc: '>=14'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
   hash:
-    md5: 86bc20552bf46075e3d92b67f089172d
-    sha256: 1544760538a40bcd8ace2b1d8ebe3eb5807ac268641f8acdc18c69c5ebfeaf64
+    md5: cffd3bdd58090148f4cfcd831f4b26ab
+    sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
   category: main
   optional: false
 - name: tk
@@ -38394,12 +30556,12 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    libgcc: '>=13'
+    libgcc: '>=14'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h561c983_103.conda
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
   hash:
-    md5: 631db4799bc2bfe4daccf80bb3cbc433
-    sha256: 154e73f6269f92ad5257aa2039278b083998fd19d371e150f307483fb93c07ae
+    md5: 7fc6affb9b01e567d2ef1d05b84aa6ed
+    sha256: e25c314b52764219f842b41aea2c98a059f06437392268f09b03561e4f6e5309
   category: main
   optional: false
 - name: tk
@@ -38409,10 +30571,10 @@ package:
   dependencies:
     __osx: '>=10.13'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
   hash:
-    md5: bd9f1de651dbd80b51281c694827f78f
-    sha256: 0d0b6cef83fec41bc0eb4f3b761c4621b7adfb14378051a8177bd9bb73d26779
+    md5: 6e6efb7463f8cef69dbcb4c2205bf60e
+    sha256: 7f0d9c320288532873e2d8486c331ec6d87919c9028208d3f6ac91dc8f99a67b
   category: main
   optional: false
 - name: tk
@@ -38422,10 +30584,10 @@ package:
   dependencies:
     __osx: '>=11.0'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
   hash:
-    md5: a73d54a5abba6543cb2f0af1bfbd6851
-    sha256: ad0c67cb03c163a109820dc9ecf77faf6ec7150e942d1e8bb13e5d39dc058ab7
+    md5: a9d86bc62f39b94c4661716624eb21b0
+    sha256: 799cab4b6cde62f91f750149995d149bc9db525ec12595e8a1d91b9317f038b3
   category: main
   optional: false
 - name: tomli
@@ -38469,7 +30631,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   hash:
     md5: b5325cf06a000c5b14970462ff5e4d58
@@ -38481,7 +30643,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   hash:
     md5: b5325cf06a000c5b14970462ff5e4d58
@@ -38493,7 +30655,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   hash:
     md5: b5325cf06a000c5b14970462ff5e4d58
@@ -38505,7 +30667,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   hash:
     md5: b5325cf06a000c5b14970462ff5e4d58
@@ -38517,7 +30679,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   hash:
     md5: b5325cf06a000c5b14970462ff5e4d58
@@ -38529,7 +30691,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   hash:
     md5: b5325cf06a000c5b14970462ff5e4d58
@@ -38541,7 +30703,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   hash:
     md5: b5325cf06a000c5b14970462ff5e4d58
@@ -38553,7 +30715,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   hash:
     md5: b5325cf06a000c5b14970462ff5e4d58
@@ -38565,7 +30727,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   hash:
     md5: b5325cf06a000c5b14970462ff5e4d58
@@ -38619,102 +30781,6 @@ package:
     md5: 42ef10a8f7f5d55a2e267c0d5daa6387
     sha256: 1cd52f9ccb4854c4d731438afe0e833b6b71edaf5ede661152aa98efb3a7cc70
   category: tools
-  optional: true
-- name: toolz
-  version: 1.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: c07a6153f8306e45794774cf9b13bd32
-    sha256: 4e379e1c18befb134247f56021fdf18e112fb35e64dd1691858b0a0f3bea9a45
-  category: container
-  optional: true
-- name: toolz
-  version: 1.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: c07a6153f8306e45794774cf9b13bd32
-    sha256: 4e379e1c18befb134247f56021fdf18e112fb35e64dd1691858b0a0f3bea9a45
-  category: notebooks
-  optional: true
-- name: toolz
-  version: 1.1.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: c07a6153f8306e45794774cf9b13bd32
-    sha256: 4e379e1c18befb134247f56021fdf18e112fb35e64dd1691858b0a0f3bea9a45
-  category: container
-  optional: true
-- name: toolz
-  version: 1.1.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: c07a6153f8306e45794774cf9b13bd32
-    sha256: 4e379e1c18befb134247f56021fdf18e112fb35e64dd1691858b0a0f3bea9a45
-  category: notebooks
-  optional: true
-- name: toolz
-  version: 1.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: c07a6153f8306e45794774cf9b13bd32
-    sha256: 4e379e1c18befb134247f56021fdf18e112fb35e64dd1691858b0a0f3bea9a45
-  category: container
-  optional: true
-- name: toolz
-  version: 1.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: c07a6153f8306e45794774cf9b13bd32
-    sha256: 4e379e1c18befb134247f56021fdf18e112fb35e64dd1691858b0a0f3bea9a45
-  category: notebooks
-  optional: true
-- name: toolz
-  version: 1.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: c07a6153f8306e45794774cf9b13bd32
-    sha256: 4e379e1c18befb134247f56021fdf18e112fb35e64dd1691858b0a0f3bea9a45
-  category: container
-  optional: true
-- name: toolz
-  version: 1.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: c07a6153f8306e45794774cf9b13bd32
-    sha256: 4e379e1c18befb134247f56021fdf18e112fb35e64dd1691858b0a0f3bea9a45
-  category: notebooks
   optional: true
 - name: tornado
   version: 6.5.7
@@ -38997,7 +31063,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
     md5: 37e3be7b6e2977d37b8fa5da229f5dc0
@@ -39009,7 +31075,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
     md5: 37e3be7b6e2977d37b8fa5da229f5dc0
@@ -39021,7 +31087,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
     md5: 37e3be7b6e2977d37b8fa5da229f5dc0
@@ -39033,7 +31099,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
     md5: 37e3be7b6e2977d37b8fa5da229f5dc0
@@ -39045,7 +31111,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
     md5: 37e3be7b6e2977d37b8fa5da229f5dc0
@@ -39057,7 +31123,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
     md5: 37e3be7b6e2977d37b8fa5da229f5dc0
@@ -39069,7 +31135,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
     md5: 37e3be7b6e2977d37b8fa5da229f5dc0
@@ -39081,7 +31147,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
     md5: 37e3be7b6e2977d37b8fa5da229f5dc0
@@ -39093,7 +31159,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
     md5: 37e3be7b6e2977d37b8fa5da229f5dc0
@@ -39105,7 +31171,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
     md5: 37e3be7b6e2977d37b8fa5da229f5dc0
@@ -39117,7 +31183,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
     md5: 37e3be7b6e2977d37b8fa5da229f5dc0
@@ -39129,7 +31195,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
   hash:
     md5: 37e3be7b6e2977d37b8fa5da229f5dc0
@@ -39153,7 +31219,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2026.6.1.19-pyhcf101f3_0.conda
   hash:
     md5: f23d5a5855f09bcb5026938486a9750d
@@ -39165,7 +31231,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2026.6.1.19-pyhcf101f3_0.conda
   hash:
     md5: f23d5a5855f09bcb5026938486a9750d
@@ -39177,7 +31243,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2026.6.1.19-pyhcf101f3_0.conda
   hash:
     md5: f23d5a5855f09bcb5026938486a9750d
@@ -39407,7 +31473,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.12.0'
   url: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
   hash:
@@ -39420,7 +31486,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.12.0'
   url: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
   hash:
@@ -39433,7 +31499,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.12.0'
   url: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
   hash:
@@ -39446,7 +31512,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.12.0'
   url: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
   hash:
@@ -39459,7 +31525,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.12.0'
   url: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
   hash:
@@ -39472,7 +31538,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.12.0'
   url: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
   hash:
@@ -39533,7 +31599,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   hash:
     md5: 0caa1af407ecff61170c9437a808404d
@@ -39545,7 +31611,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   hash:
     md5: 0caa1af407ecff61170c9437a808404d
@@ -39557,7 +31623,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   hash:
     md5: 0caa1af407ecff61170c9437a808404d
@@ -39569,7 +31635,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   hash:
     md5: 0caa1af407ecff61170c9437a808404d
@@ -39581,7 +31647,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   hash:
     md5: 0caa1af407ecff61170c9437a808404d
@@ -39593,7 +31659,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   hash:
     md5: 0caa1af407ecff61170c9437a808404d
@@ -39605,7 +31671,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   hash:
     md5: 0caa1af407ecff61170c9437a808404d
@@ -39617,7 +31683,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   hash:
     md5: 0caa1af407ecff61170c9437a808404d
@@ -39629,7 +31695,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   hash:
     md5: 0caa1af407ecff61170c9437a808404d
@@ -39641,7 +31707,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   hash:
     md5: 0caa1af407ecff61170c9437a808404d
@@ -39653,7 +31719,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   hash:
     md5: 0caa1af407ecff61170c9437a808404d
@@ -39665,7 +31731,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   hash:
     md5: 0caa1af407ecff61170c9437a808404d
@@ -39961,7 +32027,7 @@ package:
   category: notebooks
   optional: true
 - name: urllib3
-  version: 2.7.0
+  version: 2.6.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -39970,14 +32036,14 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: cbb88288f74dbe6ada1c6c7d0a97223e
-    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+    md5: 9272daa869e03efe68833e3dc7a02130
+    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   category: container
   optional: true
 - name: urllib3
-  version: 2.7.0
+  version: 2.6.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -39986,14 +32052,14 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: cbb88288f74dbe6ada1c6c7d0a97223e
-    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+    md5: 9272daa869e03efe68833e3dc7a02130
+    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   category: jupyter
   optional: true
 - name: urllib3
-  version: 2.7.0
+  version: 2.6.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -40002,14 +32068,14 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: cbb88288f74dbe6ada1c6c7d0a97223e
-    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+    md5: 9272daa869e03efe68833e3dc7a02130
+    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   category: notebooks
   optional: true
 - name: urllib3
-  version: 2.7.0
+  version: 2.6.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -40018,14 +32084,14 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: cbb88288f74dbe6ada1c6c7d0a97223e
-    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+    md5: 9272daa869e03efe68833e3dc7a02130
+    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   category: tools
   optional: true
 - name: urllib3
-  version: 2.7.0
+  version: 2.6.3
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -40034,14 +32100,14 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: cbb88288f74dbe6ada1c6c7d0a97223e
-    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+    md5: 9272daa869e03efe68833e3dc7a02130
+    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   category: container
   optional: true
 - name: urllib3
-  version: 2.7.0
+  version: 2.6.3
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -40050,14 +32116,14 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: cbb88288f74dbe6ada1c6c7d0a97223e
-    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+    md5: 9272daa869e03efe68833e3dc7a02130
+    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   category: jupyter
   optional: true
 - name: urllib3
-  version: 2.7.0
+  version: 2.6.3
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -40066,14 +32132,14 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: cbb88288f74dbe6ada1c6c7d0a97223e
-    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+    md5: 9272daa869e03efe68833e3dc7a02130
+    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   category: notebooks
   optional: true
 - name: urllib3
-  version: 2.7.0
+  version: 2.6.3
   manager: conda
   platform: linux-aarch64
   dependencies:
@@ -40082,14 +32148,14 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: cbb88288f74dbe6ada1c6c7d0a97223e
-    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+    md5: 9272daa869e03efe68833e3dc7a02130
+    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   category: tools
   optional: true
 - name: urllib3
-  version: 2.7.0
+  version: 2.6.3
   manager: conda
   platform: osx-64
   dependencies:
@@ -40098,14 +32164,14 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: cbb88288f74dbe6ada1c6c7d0a97223e
-    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+    md5: 9272daa869e03efe68833e3dc7a02130
+    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   category: container
   optional: true
 - name: urllib3
-  version: 2.7.0
+  version: 2.6.3
   manager: conda
   platform: osx-64
   dependencies:
@@ -40114,14 +32180,14 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: cbb88288f74dbe6ada1c6c7d0a97223e
-    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+    md5: 9272daa869e03efe68833e3dc7a02130
+    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   category: jupyter
   optional: true
 - name: urllib3
-  version: 2.7.0
+  version: 2.6.3
   manager: conda
   platform: osx-64
   dependencies:
@@ -40130,14 +32196,14 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: cbb88288f74dbe6ada1c6c7d0a97223e
-    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+    md5: 9272daa869e03efe68833e3dc7a02130
+    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   category: notebooks
   optional: true
 - name: urllib3
-  version: 2.7.0
+  version: 2.6.3
   manager: conda
   platform: osx-64
   dependencies:
@@ -40146,14 +32212,14 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: cbb88288f74dbe6ada1c6c7d0a97223e
-    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+    md5: 9272daa869e03efe68833e3dc7a02130
+    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   category: tools
   optional: true
 - name: urllib3
-  version: 2.7.0
+  version: 2.6.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -40162,14 +32228,14 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: cbb88288f74dbe6ada1c6c7d0a97223e
-    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+    md5: 9272daa869e03efe68833e3dc7a02130
+    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   category: container
   optional: true
 - name: urllib3
-  version: 2.7.0
+  version: 2.6.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -40178,14 +32244,14 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: cbb88288f74dbe6ada1c6c7d0a97223e
-    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+    md5: 9272daa869e03efe68833e3dc7a02130
+    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   category: jupyter
   optional: true
 - name: urllib3
-  version: 2.7.0
+  version: 2.6.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -40194,14 +32260,14 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: cbb88288f74dbe6ada1c6c7d0a97223e
-    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+    md5: 9272daa869e03efe68833e3dc7a02130
+    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   category: notebooks
   optional: true
 - name: urllib3
-  version: 2.7.0
+  version: 2.6.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -40210,10 +32276,10 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: cbb88288f74dbe6ada1c6c7d0a97223e
-    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+    md5: 9272daa869e03efe68833e3dc7a02130
+    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   category: tools
   optional: true
 - name: virtualenv
@@ -40242,7 +32308,7 @@ package:
     filelock: '>=3.24.2,<4'
     importlib-metadata: '>=6.6'
     platformdirs: '>=3.9.1,<5'
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.13.2'
   url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.39.0-pyhcf101f3_0.conda
   hash:
@@ -40259,7 +32325,7 @@ package:
     filelock: '>=3.24.2,<4'
     importlib-metadata: '>=6.6'
     platformdirs: '>=3.9.1,<5'
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.13.2'
   url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.39.0-pyhcf101f3_0.conda
   hash:
@@ -40276,7 +32342,7 @@ package:
     filelock: '>=3.24.2,<4'
     importlib-metadata: '>=6.6'
     platformdirs: '>=3.9.1,<5'
-    python: ''
+    python: '>=3.10'
     typing_extensions: '>=4.13.2'
   url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.39.0-pyhcf101f3_0.conda
   hash:
@@ -40285,195 +32351,195 @@ package:
   category: tools
   optional: true
 - name: wcwidth
-  version: 0.8.1
+  version: 0.2.14
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 7e1e5ff31239f9cd5855714df8a3783d
+    sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   category: container
   optional: true
 - name: wcwidth
-  version: 0.8.1
+  version: 0.2.14
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 7e1e5ff31239f9cd5855714df8a3783d
+    sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   category: jupyter
   optional: true
 - name: wcwidth
-  version: 0.8.1
+  version: 0.2.14
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 7e1e5ff31239f9cd5855714df8a3783d
+    sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   category: notebooks
   optional: true
 - name: wcwidth
-  version: 0.8.1
+  version: 0.2.14
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 7e1e5ff31239f9cd5855714df8a3783d
+    sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   category: tools
   optional: true
 - name: wcwidth
-  version: 0.8.1
+  version: 0.2.14
   manager: conda
   platform: linux-aarch64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 7e1e5ff31239f9cd5855714df8a3783d
+    sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   category: container
   optional: true
 - name: wcwidth
-  version: 0.8.1
+  version: 0.2.14
   manager: conda
   platform: linux-aarch64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 7e1e5ff31239f9cd5855714df8a3783d
+    sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   category: jupyter
   optional: true
 - name: wcwidth
-  version: 0.8.1
+  version: 0.2.14
   manager: conda
   platform: linux-aarch64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 7e1e5ff31239f9cd5855714df8a3783d
+    sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   category: notebooks
   optional: true
 - name: wcwidth
-  version: 0.8.1
+  version: 0.2.14
   manager: conda
   platform: linux-aarch64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 7e1e5ff31239f9cd5855714df8a3783d
+    sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   category: tools
   optional: true
 - name: wcwidth
-  version: 0.8.1
+  version: 0.2.14
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 7e1e5ff31239f9cd5855714df8a3783d
+    sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   category: container
   optional: true
 - name: wcwidth
-  version: 0.8.1
+  version: 0.2.14
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 7e1e5ff31239f9cd5855714df8a3783d
+    sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   category: jupyter
   optional: true
 - name: wcwidth
-  version: 0.8.1
+  version: 0.2.14
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 7e1e5ff31239f9cd5855714df8a3783d
+    sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   category: notebooks
   optional: true
 - name: wcwidth
-  version: 0.8.1
+  version: 0.2.14
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 7e1e5ff31239f9cd5855714df8a3783d
+    sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   category: tools
   optional: true
 - name: wcwidth
-  version: 0.8.1
+  version: 0.2.14
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 7e1e5ff31239f9cd5855714df8a3783d
+    sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   category: container
   optional: true
 - name: wcwidth
-  version: 0.8.1
+  version: 0.2.14
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 7e1e5ff31239f9cd5855714df8a3783d
+    sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   category: jupyter
   optional: true
 - name: wcwidth
-  version: 0.8.1
+  version: 0.2.14
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 7e1e5ff31239f9cd5855714df8a3783d
+    sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   category: notebooks
   optional: true
 - name: wcwidth
-  version: 0.8.1
+  version: 0.2.14
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 19c961dd9cab6c3e13cd195f0176dbfa
-    sha256: 5ddde23d65aecde7e8dac0b9d9c7821ead2b87a320d787f9e4288c0ee00fa332
+    md5: 7e1e5ff31239f9cd5855714df8a3783d
+    sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
   category: tools
   optional: true
 - name: webcolors
@@ -40859,66 +32925,6 @@ package:
     md5: dc257b7e7cad9b79c1dfba194e92297b
     sha256: 826af5e2c09e5e45361fa19168f46ff524e7a766022615678c3a670c45895d9a
   category: jupyter
-  optional: true
-- name: xarray
-  version: 2026.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    numpy: '>=1.26'
-    packaging: '>=24.2'
-    pandas: '>=2.2'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.4.0-pyhc364b38_0.conda
-  hash:
-    md5: 099794df685f800c3f319ff4742dc1bb
-    sha256: 9f5f5905afea6e0188aa6887aed0809033143343a7af06983f4b390c2286d2d7
-  category: notebooks
-  optional: true
-- name: xarray
-  version: 2026.4.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    numpy: '>=1.26'
-    packaging: '>=24.2'
-    pandas: '>=2.2'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.4.0-pyhc364b38_0.conda
-  hash:
-    md5: 099794df685f800c3f319ff4742dc1bb
-    sha256: 9f5f5905afea6e0188aa6887aed0809033143343a7af06983f4b390c2286d2d7
-  category: notebooks
-  optional: true
-- name: xarray
-  version: 2026.4.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    numpy: '>=1.26'
-    packaging: '>=24.2'
-    pandas: '>=2.2'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.4.0-pyhc364b38_0.conda
-  hash:
-    md5: 099794df685f800c3f319ff4742dc1bb
-    sha256: 9f5f5905afea6e0188aa6887aed0809033143343a7af06983f4b390c2286d2d7
-  category: notebooks
-  optional: true
-- name: xarray
-  version: 2026.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    numpy: '>=1.26'
-    packaging: '>=24.2'
-    pandas: '>=2.2'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.4.0-pyhc364b38_0.conda
-  hash:
-    md5: 099794df685f800c3f319ff4742dc1bb
-    sha256: 9f5f5905afea6e0188aa6887aed0809033143343a7af06983f4b390c2286d2d7
-  category: notebooks
   optional: true
 - name: xattr
   version: 1.3.0
@@ -41009,298 +33015,6 @@ package:
     sha256: 89152175f45b5e84e0f1575848f607e305ffc122ab59d9704ea77ce699b1bd2b
   category: notebooks
   optional: true
-- name: xorg-libxau
-  version: 1.0.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
-  hash:
-    md5: b2895afaf55bf96a8c8282a2e47a5de0
-    sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
-  category: container
-  optional: true
-- name: xorg-libxau
-  version: 1.0.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
-  hash:
-    md5: b2895afaf55bf96a8c8282a2e47a5de0
-    sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
-  category: notebooks
-  optional: true
-- name: xorg-libxau
-  version: 1.0.12
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
-  hash:
-    md5: 1c246e1105000c3660558459e2fd6d43
-    sha256: e9f6e931feeb2f40e1fdbafe41d3b665f1ab6cb39c5880a1fcf9f79a3f3c84a5
-  category: container
-  optional: true
-- name: xorg-libxau
-  version: 1.0.12
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
-  hash:
-    md5: 1c246e1105000c3660558459e2fd6d43
-    sha256: e9f6e931feeb2f40e1fdbafe41d3b665f1ab6cb39c5880a1fcf9f79a3f3c84a5
-  category: notebooks
-  optional: true
-- name: xorg-libxau
-  version: 1.0.12
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.12-h8616949_1.conda
-  hash:
-    md5: 47f1b8b4a76ebd0cd22bd7153e54a4dc
-    sha256: 928f28bd278c7da674b57d71b2e7f4ac4e7c7ce56b0bf0f60d6a074366a2e76d
-  category: container
-  optional: true
-- name: xorg-libxau
-  version: 1.0.12
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.12-h8616949_1.conda
-  hash:
-    md5: 47f1b8b4a76ebd0cd22bd7153e54a4dc
-    sha256: 928f28bd278c7da674b57d71b2e7f4ac4e7c7ce56b0bf0f60d6a074366a2e76d
-  category: notebooks
-  optional: true
-- name: xorg-libxau
-  version: 1.0.12
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
-  hash:
-    md5: 78b548eed8227a689f93775d5d23ae09
-    sha256: adae11db0f66f86156569415ed79cda75b2dbf4bea48d1577831db701438164f
-  category: container
-  optional: true
-- name: xorg-libxau
-  version: 1.0.12
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
-  hash:
-    md5: 78b548eed8227a689f93775d5d23ae09
-    sha256: adae11db0f66f86156569415ed79cda75b2dbf4bea48d1577831db701438164f
-  category: notebooks
-  optional: true
-- name: xorg-libxdmcp
-  version: 1.1.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
-  hash:
-    md5: 1dafce8548e38671bea82e3f5c6ce22f
-    sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
-  category: container
-  optional: true
-- name: xorg-libxdmcp
-  version: 1.1.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
-  hash:
-    md5: 1dafce8548e38671bea82e3f5c6ce22f
-    sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
-  category: notebooks
-  optional: true
-- name: xorg-libxdmcp
-  version: 1.1.5
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_1.conda
-  hash:
-    md5: bff06dcde4a707339d66d45d96ceb2e2
-    sha256: 128d72f36bcc8d2b4cdbec07507542e437c7d67f677b7d77b71ed9eeac7d6df1
-  category: container
-  optional: true
-- name: xorg-libxdmcp
-  version: 1.1.5
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_1.conda
-  hash:
-    md5: bff06dcde4a707339d66d45d96ceb2e2
-    sha256: 128d72f36bcc8d2b4cdbec07507542e437c7d67f677b7d77b71ed9eeac7d6df1
-  category: notebooks
-  optional: true
-- name: xorg-libxdmcp
-  version: 1.1.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h8616949_1.conda
-  hash:
-    md5: 435446d9d7db8e094d2c989766cfb146
-    sha256: b7b291cc5fd4e1223058542fca46f462221027779920dd433d68b98e858a4afc
-  category: container
-  optional: true
-- name: xorg-libxdmcp
-  version: 1.1.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h8616949_1.conda
-  hash:
-    md5: 435446d9d7db8e094d2c989766cfb146
-    sha256: b7b291cc5fd4e1223058542fca46f462221027779920dd433d68b98e858a4afc
-  category: notebooks
-  optional: true
-- name: xorg-libxdmcp
-  version: 1.1.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
-  hash:
-    md5: 9d1299ace1924aa8f4e0bc8e71dd0cf7
-    sha256: f7fa0de519d8da589995a1fe78ef74556bb8bc4172079ae3a8d20c3c81354906
-  category: container
-  optional: true
-- name: xorg-libxdmcp
-  version: 1.1.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
-  hash:
-    md5: 9d1299ace1924aa8f4e0bc8e71dd0cf7
-    sha256: f7fa0de519d8da589995a1fe78ef74556bb8bc4172079ae3a8d20c3c81354906
-  category: notebooks
-  optional: true
-- name: xyzservices
-  version: 2026.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4487b9c371d0161d54b5c7bbd890c0fc
-    sha256: 663ea9b00d68c2da309114923924686ab6d3f59ef1b196c5029ba16799e7bb07
-  category: container
-  optional: true
-- name: xyzservices
-  version: 2026.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4487b9c371d0161d54b5c7bbd890c0fc
-    sha256: 663ea9b00d68c2da309114923924686ab6d3f59ef1b196c5029ba16799e7bb07
-  category: notebooks
-  optional: true
-- name: xyzservices
-  version: 2026.3.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4487b9c371d0161d54b5c7bbd890c0fc
-    sha256: 663ea9b00d68c2da309114923924686ab6d3f59ef1b196c5029ba16799e7bb07
-  category: container
-  optional: true
-- name: xyzservices
-  version: 2026.3.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4487b9c371d0161d54b5c7bbd890c0fc
-    sha256: 663ea9b00d68c2da309114923924686ab6d3f59ef1b196c5029ba16799e7bb07
-  category: notebooks
-  optional: true
-- name: xyzservices
-  version: 2026.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4487b9c371d0161d54b5c7bbd890c0fc
-    sha256: 663ea9b00d68c2da309114923924686ab6d3f59ef1b196c5029ba16799e7bb07
-  category: container
-  optional: true
-- name: xyzservices
-  version: 2026.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4487b9c371d0161d54b5c7bbd890c0fc
-    sha256: 663ea9b00d68c2da309114923924686ab6d3f59ef1b196c5029ba16799e7bb07
-  category: notebooks
-  optional: true
-- name: xyzservices
-  version: 2026.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4487b9c371d0161d54b5c7bbd890c0fc
-    sha256: 663ea9b00d68c2da309114923924686ab6d3f59ef1b196c5029ba16799e7bb07
-  category: container
-  optional: true
-- name: xyzservices
-  version: 2026.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4487b9c371d0161d54b5c7bbd890c0fc
-    sha256: 663ea9b00d68c2da309114923924686ab6d3f59ef1b196c5029ba16799e7bb07
-  category: notebooks
-  optional: true
 - name: yaml
   version: 0.2.5
   manager: conda
@@ -41680,102 +33394,6 @@ package:
     sha256: 01fd50d2801b23b59fafea6bf704a6c5faf0f5969104400eae0e6572cb2e5304
   category: tools
   optional: true
-- name: zict
-  version: 3.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: e52c2ef711ccf31bb7f70ca87d144b9e
-    sha256: 5488542dceeb9f2874e726646548ecc5608060934d6f9ceaa7c6a48c61f9cc8d
-  category: container
-  optional: true
-- name: zict
-  version: 3.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: e52c2ef711ccf31bb7f70ca87d144b9e
-    sha256: 5488542dceeb9f2874e726646548ecc5608060934d6f9ceaa7c6a48c61f9cc8d
-  category: notebooks
-  optional: true
-- name: zict
-  version: 3.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: e52c2ef711ccf31bb7f70ca87d144b9e
-    sha256: 5488542dceeb9f2874e726646548ecc5608060934d6f9ceaa7c6a48c61f9cc8d
-  category: container
-  optional: true
-- name: zict
-  version: 3.0.0
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: e52c2ef711ccf31bb7f70ca87d144b9e
-    sha256: 5488542dceeb9f2874e726646548ecc5608060934d6f9ceaa7c6a48c61f9cc8d
-  category: notebooks
-  optional: true
-- name: zict
-  version: 3.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: e52c2ef711ccf31bb7f70ca87d144b9e
-    sha256: 5488542dceeb9f2874e726646548ecc5608060934d6f9ceaa7c6a48c61f9cc8d
-  category: container
-  optional: true
-- name: zict
-  version: 3.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: e52c2ef711ccf31bb7f70ca87d144b9e
-    sha256: 5488542dceeb9f2874e726646548ecc5608060934d6f9ceaa7c6a48c61f9cc8d
-  category: notebooks
-  optional: true
-- name: zict
-  version: 3.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: e52c2ef711ccf31bb7f70ca87d144b9e
-    sha256: 5488542dceeb9f2874e726646548ecc5608060934d6f9ceaa7c6a48c61f9cc8d
-  category: container
-  optional: true
-- name: zict
-  version: 3.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: e52c2ef711ccf31bb7f70ca87d144b9e
-    sha256: 5488542dceeb9f2874e726646548ecc5608060934d6f9ceaa7c6a48c61f9cc8d
-  category: notebooks
-  optional: true
 - name: zipp
   version: 4.1.0
   manager: conda
@@ -41829,7 +33447,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
   hash:
     md5: ba3dcdc8584155c97c648ae9c044b7a3
@@ -41841,7 +33459,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
   hash:
     md5: ba3dcdc8584155c97c648ae9c044b7a3
@@ -41853,7 +33471,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
   hash:
     md5: ba3dcdc8584155c97c648ae9c044b7a3
@@ -41865,7 +33483,7 @@ package:
   manager: conda
   platform: linux-aarch64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
   hash:
     md5: ba3dcdc8584155c97c648ae9c044b7a3
@@ -41877,7 +33495,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
   hash:
     md5: ba3dcdc8584155c97c648ae9c044b7a3
@@ -41889,7 +33507,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
   hash:
     md5: ba3dcdc8584155c97c648ae9c044b7a3
@@ -41901,7 +33519,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
   hash:
     md5: ba3dcdc8584155c97c648ae9c044b7a3
@@ -41913,7 +33531,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
   hash:
     md5: ba3dcdc8584155c97c648ae9c044b7a3
@@ -41925,7 +33543,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
   hash:
     md5: ba3dcdc8584155c97c648ae9c044b7a3
@@ -41937,7 +33555,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
   hash:
     md5: ba3dcdc8584155c97c648ae9c044b7a3
@@ -41949,7 +33567,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
   hash:
     md5: ba3dcdc8584155c97c648ae9c044b7a3
@@ -41961,7 +33579,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
+    python: '>=3.10'
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
   hash:
     md5: ba3dcdc8584155c97c648ae9c044b7a3
@@ -42068,112 +33686,6 @@ package:
   hash:
     md5: f1c0bce276210bed45a04949cfe8dc20
     sha256: 8dd2ac25f0ba714263aac5832d46985648f4bfb9b305b5021d702079badc08d2
-  category: notebooks
-  optional: true
-- name: zlib-ng
-  version: 2.3.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
-  hash:
-    md5: 2aadb0d17215603a82a2a6b0afd9a4cb
-    sha256: ea4e50c465d70236408cb0bfe0115609fd14db1adcd8bd30d8918e0291f8a75f
-  category: container
-  optional: true
-- name: zlib-ng
-  version: 2.3.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
-  hash:
-    md5: 2aadb0d17215603a82a2a6b0afd9a4cb
-    sha256: ea4e50c465d70236408cb0bfe0115609fd14db1adcd8bd30d8918e0291f8a75f
-  category: notebooks
-  optional: true
-- name: zlib-ng
-  version: 2.3.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-ng-2.3.3-ha7cb516_1.conda
-  hash:
-    md5: f731af71c723065d91b4c01bb822641b
-    sha256: 638a3a41a4fbfed52d3c60c8ef5a3693b3f12a5b1a3f58fa29f5698d0a0702e2
-  category: container
-  optional: true
-- name: zlib-ng
-  version: 2.3.3
-  manager: conda
-  platform: linux-aarch64
-  dependencies:
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-ng-2.3.3-ha7cb516_1.conda
-  hash:
-    md5: f731af71c723065d91b4c01bb822641b
-    sha256: 638a3a41a4fbfed52d3c60c8ef5a3693b3f12a5b1a3f58fa29f5698d0a0702e2
-  category: notebooks
-  optional: true
-- name: zlib-ng
-  version: 2.3.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-ng-2.3.3-h8bce59a_1.conda
-  hash:
-    md5: b3ecb6480fd46194e3f7dd0ff4445dff
-    sha256: 4a1beb656761c7d8c9a53474bfd3932c30d82af5d93a32b8ef626c01c059d981
-  category: container
-  optional: true
-- name: zlib-ng
-  version: 2.3.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-ng-2.3.3-h8bce59a_1.conda
-  hash:
-    md5: b3ecb6480fd46194e3f7dd0ff4445dff
-    sha256: 4a1beb656761c7d8c9a53474bfd3932c30d82af5d93a32b8ef626c01c059d981
-  category: notebooks
-  optional: true
-- name: zlib-ng
-  version: 2.3.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
-  hash:
-    md5: d99c2a23a31b0172e90f456f580b695e
-    sha256: a339606a6b224bb230ff3d711e801934f3b3844271df9720165e0353716580d4
-  category: container
-  optional: true
-- name: zlib-ng
-  version: 2.3.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
-  hash:
-    md5: d99c2a23a31b0172e90f456f580b695e
-    sha256: a339606a6b224bb230ff3d711e801934f3b3844271df9720165e0353716580d4
   category: notebooks
   optional: true
 - name: zstandard
@@ -43666,6 +35178,158 @@ package:
     sha256: 1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0
   category: container
   optional: true
+- name: bokeh
+  version: 3.9.1
+  manager: pip
+  platform: linux-64
+  dependencies:
+    contourpy: '>=1.2'
+    jinja2: '>=2.9'
+    narwhals: '>=1.13'
+    numpy: '>=1.16'
+    packaging: '>=16.8'
+    pillow: '>=7.1.0'
+    pyyaml: '>=3.10'
+    tornado: '>=6.2'
+    xyzservices: '>=2021.09.1'
+  url: https://files.pythonhosted.org/packages/f3/54/40ff985187f0fd1afcedebc23eda0ba92bdbea1e0605cbb878b45391e5e0/bokeh-3.9.1-py3-none-any.whl
+  hash:
+    sha256: 8bf2aae574509055fbd6b68f023046bebc91b0bbd631d204d0d60863b4237dbd
+  category: container
+  optional: true
+- name: bokeh
+  version: 3.9.1
+  manager: pip
+  platform: linux-64
+  dependencies:
+    contourpy: '>=1.2'
+    jinja2: '>=2.9'
+    narwhals: '>=1.13'
+    numpy: '>=1.16'
+    packaging: '>=16.8'
+    pillow: '>=7.1.0'
+    pyyaml: '>=3.10'
+    tornado: '>=6.2'
+    xyzservices: '>=2021.09.1'
+  url: https://files.pythonhosted.org/packages/f3/54/40ff985187f0fd1afcedebc23eda0ba92bdbea1e0605cbb878b45391e5e0/bokeh-3.9.1-py3-none-any.whl
+  hash:
+    sha256: 8bf2aae574509055fbd6b68f023046bebc91b0bbd631d204d0d60863b4237dbd
+  category: notebooks
+  optional: true
+- name: bokeh
+  version: 3.9.1
+  manager: pip
+  platform: linux-aarch64
+  dependencies:
+    contourpy: '>=1.2'
+    jinja2: '>=2.9'
+    narwhals: '>=1.13'
+    numpy: '>=1.16'
+    packaging: '>=16.8'
+    pillow: '>=7.1.0'
+    pyyaml: '>=3.10'
+    tornado: '>=6.2'
+    xyzservices: '>=2021.09.1'
+  url: https://files.pythonhosted.org/packages/f3/54/40ff985187f0fd1afcedebc23eda0ba92bdbea1e0605cbb878b45391e5e0/bokeh-3.9.1-py3-none-any.whl
+  hash:
+    sha256: 8bf2aae574509055fbd6b68f023046bebc91b0bbd631d204d0d60863b4237dbd
+  category: container
+  optional: true
+- name: bokeh
+  version: 3.9.1
+  manager: pip
+  platform: linux-aarch64
+  dependencies:
+    contourpy: '>=1.2'
+    jinja2: '>=2.9'
+    narwhals: '>=1.13'
+    numpy: '>=1.16'
+    packaging: '>=16.8'
+    pillow: '>=7.1.0'
+    pyyaml: '>=3.10'
+    tornado: '>=6.2'
+    xyzservices: '>=2021.09.1'
+  url: https://files.pythonhosted.org/packages/f3/54/40ff985187f0fd1afcedebc23eda0ba92bdbea1e0605cbb878b45391e5e0/bokeh-3.9.1-py3-none-any.whl
+  hash:
+    sha256: 8bf2aae574509055fbd6b68f023046bebc91b0bbd631d204d0d60863b4237dbd
+  category: notebooks
+  optional: true
+- name: bokeh
+  version: 3.9.1
+  manager: pip
+  platform: osx-64
+  dependencies:
+    contourpy: '>=1.2'
+    jinja2: '>=2.9'
+    narwhals: '>=1.13'
+    numpy: '>=1.16'
+    packaging: '>=16.8'
+    pillow: '>=7.1.0'
+    pyyaml: '>=3.10'
+    tornado: '>=6.2'
+    xyzservices: '>=2021.09.1'
+  url: https://files.pythonhosted.org/packages/f3/54/40ff985187f0fd1afcedebc23eda0ba92bdbea1e0605cbb878b45391e5e0/bokeh-3.9.1-py3-none-any.whl
+  hash:
+    sha256: 8bf2aae574509055fbd6b68f023046bebc91b0bbd631d204d0d60863b4237dbd
+  category: container
+  optional: true
+- name: bokeh
+  version: 3.9.1
+  manager: pip
+  platform: osx-64
+  dependencies:
+    contourpy: '>=1.2'
+    jinja2: '>=2.9'
+    narwhals: '>=1.13'
+    numpy: '>=1.16'
+    packaging: '>=16.8'
+    pillow: '>=7.1.0'
+    pyyaml: '>=3.10'
+    tornado: '>=6.2'
+    xyzservices: '>=2021.09.1'
+  url: https://files.pythonhosted.org/packages/f3/54/40ff985187f0fd1afcedebc23eda0ba92bdbea1e0605cbb878b45391e5e0/bokeh-3.9.1-py3-none-any.whl
+  hash:
+    sha256: 8bf2aae574509055fbd6b68f023046bebc91b0bbd631d204d0d60863b4237dbd
+  category: notebooks
+  optional: true
+- name: bokeh
+  version: 3.9.1
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    contourpy: '>=1.2'
+    jinja2: '>=2.9'
+    narwhals: '>=1.13'
+    numpy: '>=1.16'
+    packaging: '>=16.8'
+    pillow: '>=7.1.0'
+    pyyaml: '>=3.10'
+    tornado: '>=6.2'
+    xyzservices: '>=2021.09.1'
+  url: https://files.pythonhosted.org/packages/f3/54/40ff985187f0fd1afcedebc23eda0ba92bdbea1e0605cbb878b45391e5e0/bokeh-3.9.1-py3-none-any.whl
+  hash:
+    sha256: 8bf2aae574509055fbd6b68f023046bebc91b0bbd631d204d0d60863b4237dbd
+  category: container
+  optional: true
+- name: bokeh
+  version: 3.9.1
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    contourpy: '>=1.2'
+    jinja2: '>=2.9'
+    narwhals: '>=1.13'
+    numpy: '>=1.16'
+    packaging: '>=16.8'
+    pillow: '>=7.1.0'
+    pyyaml: '>=3.10'
+    tornado: '>=6.2'
+    xyzservices: '>=2021.09.1'
+  url: https://files.pythonhosted.org/packages/f3/54/40ff985187f0fd1afcedebc23eda0ba92bdbea1e0605cbb878b45391e5e0/bokeh-3.9.1-py3-none-any.whl
+  hash:
+    sha256: 8bf2aae574509055fbd6b68f023046bebc91b0bbd631d204d0d60863b4237dbd
+  category: notebooks
+  optional: true
 - name: boto3
   version: 1.43.0
   manager: pip
@@ -44318,6 +35982,86 @@ package:
     sha256: c1ca117dbce1fe20a5809dc96f01e1c2840f6dcc939b3ddbb1111bf330ba82df
   category: notebooks
   optional: true
+- name: cloudpickle
+  version: 3.1.2
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+  hash:
+    sha256: 9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a
+  category: container
+  optional: true
+- name: cloudpickle
+  version: 3.1.2
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+  hash:
+    sha256: 9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a
+  category: notebooks
+  optional: true
+- name: cloudpickle
+  version: 3.1.2
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+  hash:
+    sha256: 9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a
+  category: container
+  optional: true
+- name: cloudpickle
+  version: 3.1.2
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+  hash:
+    sha256: 9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a
+  category: notebooks
+  optional: true
+- name: cloudpickle
+  version: 3.1.2
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+  hash:
+    sha256: 9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a
+  category: container
+  optional: true
+- name: cloudpickle
+  version: 3.1.2
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+  hash:
+    sha256: 9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a
+  category: notebooks
+  optional: true
+- name: cloudpickle
+  version: 3.1.2
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+  hash:
+    sha256: 9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a
+  category: container
+  optional: true
+- name: cloudpickle
+  version: 3.1.2
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+  hash:
+    sha256: 9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a
+  category: notebooks
+  optional: true
 - name: cmocean
   version: 4.0.3
   manager: pip
@@ -44450,6 +36194,94 @@ package:
     sha256: 1ba10c5b6ee16229c79a05047aeda2b55eb4e80d7c7d8ecf17ec1ca600c79882
   category: tools
   optional: true
+- name: contourpy
+  version: 1.3.3
+  manager: pip
+  platform: linux-64
+  dependencies:
+    numpy: '>=1.25'
+  url: https://files.pythonhosted.org/packages/4b/32/e0f13a1c5b0f8572d0ec6ae2f6c677b7991fafd95da523159c19eff0696a/contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  hash:
+    sha256: 4debd64f124ca62069f313a9cb86656ff087786016d76927ae2cf37846b006c9
+  category: container
+  optional: true
+- name: contourpy
+  version: 1.3.3
+  manager: pip
+  platform: linux-64
+  dependencies:
+    numpy: '>=1.25'
+  url: https://files.pythonhosted.org/packages/4b/32/e0f13a1c5b0f8572d0ec6ae2f6c677b7991fafd95da523159c19eff0696a/contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  hash:
+    sha256: 4debd64f124ca62069f313a9cb86656ff087786016d76927ae2cf37846b006c9
+  category: notebooks
+  optional: true
+- name: contourpy
+  version: 1.3.3
+  manager: pip
+  platform: linux-aarch64
+  dependencies:
+    numpy: '>=1.25'
+  url: https://files.pythonhosted.org/packages/73/23/90e31ceeed1de63058a02cb04b12f2de4b40e3bef5e082a7c18d9c8ae281/contourpy-1.3.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
+  hash:
+    sha256: 348ac1f5d4f1d66d3322420f01d42e43122f43616e0f194fc1c9f5d830c5b286
+  category: container
+  optional: true
+- name: contourpy
+  version: 1.3.3
+  manager: pip
+  platform: linux-aarch64
+  dependencies:
+    numpy: '>=1.25'
+  url: https://files.pythonhosted.org/packages/73/23/90e31ceeed1de63058a02cb04b12f2de4b40e3bef5e082a7c18d9c8ae281/contourpy-1.3.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
+  hash:
+    sha256: 348ac1f5d4f1d66d3322420f01d42e43122f43616e0f194fc1c9f5d830c5b286
+  category: notebooks
+  optional: true
+- name: contourpy
+  version: 1.3.3
+  manager: pip
+  platform: osx-64
+  dependencies:
+    numpy: '>=1.25'
+  url: https://files.pythonhosted.org/packages/68/35/0167aad910bbdb9599272bd96d01a9ec6852f36b9455cf2ca67bd4cc2d23/contourpy-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl
+  hash:
+    sha256: 177fb367556747a686509d6fef71d221a4b198a3905fe824430e5ea0fda54eb5
+  category: container
+  optional: true
+- name: contourpy
+  version: 1.3.3
+  manager: pip
+  platform: osx-64
+  dependencies:
+    numpy: '>=1.25'
+  url: https://files.pythonhosted.org/packages/68/35/0167aad910bbdb9599272bd96d01a9ec6852f36b9455cf2ca67bd4cc2d23/contourpy-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl
+  hash:
+    sha256: 177fb367556747a686509d6fef71d221a4b198a3905fe824430e5ea0fda54eb5
+  category: notebooks
+  optional: true
+- name: contourpy
+  version: 1.3.3
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    numpy: '>=1.25'
+  url: https://files.pythonhosted.org/packages/96/e4/7adcd9c8362745b2210728f209bfbcf7d91ba868a2c5f40d8b58f54c509b/contourpy-1.3.3-cp313-cp313-macosx_11_0_arm64.whl
+  hash:
+    sha256: d002b6f00d73d69333dac9d0b8d5e84d9724ff9ef044fd63c5986e62b7c9e1b1
+  category: container
+  optional: true
+- name: contourpy
+  version: 1.3.3
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    numpy: '>=1.25'
+  url: https://files.pythonhosted.org/packages/96/e4/7adcd9c8362745b2210728f209bfbcf7d91ba868a2c5f40d8b58f54c509b/contourpy-1.3.3-cp313-cp313-macosx_11_0_arm64.whl
+  hash:
+    sha256: d002b6f00d73d69333dac9d0b8d5e84d9724ff9ef044fd63c5986e62b7c9e1b1
+  category: notebooks
+  optional: true
 - name: curlify
   version: 2.2.1
   manager: pip
@@ -44532,6 +36364,150 @@ package:
   url: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
   hash:
     sha256: 85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30
+  category: notebooks
+  optional: true
+- name: dask
+  version: 2026.6.0
+  manager: pip
+  platform: linux-64
+  dependencies:
+    click: '>=8.1'
+    cloudpickle: '>=3.0.0'
+    distributed: '>=2026.6.0,<2026.6.1'
+    fsspec: '>=2021.09.0'
+    packaging: '>=20.0'
+    partd: '>=1.4.0'
+    pyyaml: '>=5.4.1'
+    toolz: '>=0.12.0'
+  url: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
+  hash:
+    sha256: 1539859071065dca379ca592ff76e911cd7965dc466da0040354ab466179189b
+  category: container
+  optional: true
+- name: dask
+  version: 2026.6.0
+  manager: pip
+  platform: linux-64
+  dependencies:
+    click: '>=8.1'
+    cloudpickle: '>=3.0.0'
+    distributed: '>=2026.6.0,<2026.6.1'
+    fsspec: '>=2021.09.0'
+    packaging: '>=20.0'
+    partd: '>=1.4.0'
+    pyyaml: '>=5.4.1'
+    toolz: '>=0.12.0'
+  url: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
+  hash:
+    sha256: 1539859071065dca379ca592ff76e911cd7965dc466da0040354ab466179189b
+  category: notebooks
+  optional: true
+- name: dask
+  version: 2026.6.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies:
+    click: '>=8.1'
+    cloudpickle: '>=3.0.0'
+    distributed: '>=2026.6.0,<2026.6.1'
+    fsspec: '>=2021.09.0'
+    packaging: '>=20.0'
+    partd: '>=1.4.0'
+    pyyaml: '>=5.4.1'
+    toolz: '>=0.12.0'
+  url: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
+  hash:
+    sha256: 1539859071065dca379ca592ff76e911cd7965dc466da0040354ab466179189b
+  category: container
+  optional: true
+- name: dask
+  version: 2026.6.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies:
+    click: '>=8.1'
+    cloudpickle: '>=3.0.0'
+    distributed: '>=2026.6.0,<2026.6.1'
+    fsspec: '>=2021.09.0'
+    packaging: '>=20.0'
+    partd: '>=1.4.0'
+    pyyaml: '>=5.4.1'
+    toolz: '>=0.12.0'
+  url: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
+  hash:
+    sha256: 1539859071065dca379ca592ff76e911cd7965dc466da0040354ab466179189b
+  category: notebooks
+  optional: true
+- name: dask
+  version: 2026.6.0
+  manager: pip
+  platform: osx-64
+  dependencies:
+    click: '>=8.1'
+    cloudpickle: '>=3.0.0'
+    distributed: '>=2026.6.0,<2026.6.1'
+    fsspec: '>=2021.09.0'
+    packaging: '>=20.0'
+    partd: '>=1.4.0'
+    pyyaml: '>=5.4.1'
+    toolz: '>=0.12.0'
+  url: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
+  hash:
+    sha256: 1539859071065dca379ca592ff76e911cd7965dc466da0040354ab466179189b
+  category: container
+  optional: true
+- name: dask
+  version: 2026.6.0
+  manager: pip
+  platform: osx-64
+  dependencies:
+    click: '>=8.1'
+    cloudpickle: '>=3.0.0'
+    distributed: '>=2026.6.0,<2026.6.1'
+    fsspec: '>=2021.09.0'
+    packaging: '>=20.0'
+    partd: '>=1.4.0'
+    pyyaml: '>=5.4.1'
+    toolz: '>=0.12.0'
+  url: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
+  hash:
+    sha256: 1539859071065dca379ca592ff76e911cd7965dc466da0040354ab466179189b
+  category: notebooks
+  optional: true
+- name: dask
+  version: 2026.6.0
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    click: '>=8.1'
+    cloudpickle: '>=3.0.0'
+    distributed: '>=2026.6.0,<2026.6.1'
+    fsspec: '>=2021.09.0'
+    packaging: '>=20.0'
+    partd: '>=1.4.0'
+    pyyaml: '>=5.4.1'
+    toolz: '>=0.12.0'
+  url: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
+  hash:
+    sha256: 1539859071065dca379ca592ff76e911cd7965dc466da0040354ab466179189b
+  category: container
+  optional: true
+- name: dask
+  version: 2026.6.0
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    click: '>=8.1'
+    cloudpickle: '>=3.0.0'
+    distributed: '>=2026.6.0,<2026.6.1'
+    fsspec: '>=2021.09.0'
+    packaging: '>=20.0'
+    partd: '>=1.4.0'
+    pyyaml: '>=5.4.1'
+    toolz: '>=0.12.0'
+  url: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
+  hash:
+    sha256: 1539859071065dca379ca592ff76e911cd7965dc466da0040354ab466179189b
   category: notebooks
   optional: true
 - name: dask-gateway
@@ -44821,6 +36797,198 @@ package:
   hash:
     sha256: 5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19
   category: tools
+  optional: true
+- name: distributed
+  version: 2026.6.0
+  manager: pip
+  platform: linux-64
+  dependencies:
+    click: '>=8.0'
+    cloudpickle: '>=3.0.0'
+    dask: '>=2026.6.0,<2026.6.1'
+    jinja2: '>=2.10.3'
+    locket: '>=1.0.0'
+    msgpack: '>=1.0.2'
+    packaging: '>=20.0'
+    psutil: '>=5.8.0'
+    pyyaml: '>=5.4.1'
+    sortedcontainers: '>=2.0.5'
+    tblib: '>=1.6.0,<3.2.0 || >3.2.0,<3.2.1 || >3.2.1'
+    toolz: '>=0.12.0'
+    tornado: '>=6.2.0'
+    zict: '>=3.0.0'
+  url: https://files.pythonhosted.org/packages/b4/62/674ba5ada6de5615b458d768c0f0fb1a7b53299486fb38a36e0694f3c617/distributed-2026.6.0-py3-none-any.whl
+  hash:
+    sha256: ca034e8b4d05b8a92f0655ebd0914e82308509a213889456d7ddd2bd0543439b
+  category: container
+  optional: true
+- name: distributed
+  version: 2026.6.0
+  manager: pip
+  platform: linux-64
+  dependencies:
+    click: '>=8.0'
+    cloudpickle: '>=3.0.0'
+    dask: '>=2026.6.0,<2026.6.1'
+    jinja2: '>=2.10.3'
+    locket: '>=1.0.0'
+    msgpack: '>=1.0.2'
+    packaging: '>=20.0'
+    psutil: '>=5.8.0'
+    pyyaml: '>=5.4.1'
+    sortedcontainers: '>=2.0.5'
+    tblib: '>=1.6.0,<3.2.0 || >3.2.0,<3.2.1 || >3.2.1'
+    toolz: '>=0.12.0'
+    tornado: '>=6.2.0'
+    zict: '>=3.0.0'
+  url: https://files.pythonhosted.org/packages/b4/62/674ba5ada6de5615b458d768c0f0fb1a7b53299486fb38a36e0694f3c617/distributed-2026.6.0-py3-none-any.whl
+  hash:
+    sha256: ca034e8b4d05b8a92f0655ebd0914e82308509a213889456d7ddd2bd0543439b
+  category: notebooks
+  optional: true
+- name: distributed
+  version: 2026.6.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies:
+    click: '>=8.0'
+    cloudpickle: '>=3.0.0'
+    dask: '>=2026.6.0,<2026.6.1'
+    jinja2: '>=2.10.3'
+    locket: '>=1.0.0'
+    msgpack: '>=1.0.2'
+    packaging: '>=20.0'
+    psutil: '>=5.8.0'
+    pyyaml: '>=5.4.1'
+    sortedcontainers: '>=2.0.5'
+    tblib: '>=1.6.0,<3.2.0 || >3.2.0,<3.2.1 || >3.2.1'
+    toolz: '>=0.12.0'
+    tornado: '>=6.2.0'
+    zict: '>=3.0.0'
+  url: https://files.pythonhosted.org/packages/b4/62/674ba5ada6de5615b458d768c0f0fb1a7b53299486fb38a36e0694f3c617/distributed-2026.6.0-py3-none-any.whl
+  hash:
+    sha256: ca034e8b4d05b8a92f0655ebd0914e82308509a213889456d7ddd2bd0543439b
+  category: container
+  optional: true
+- name: distributed
+  version: 2026.6.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies:
+    click: '>=8.0'
+    cloudpickle: '>=3.0.0'
+    dask: '>=2026.6.0,<2026.6.1'
+    jinja2: '>=2.10.3'
+    locket: '>=1.0.0'
+    msgpack: '>=1.0.2'
+    packaging: '>=20.0'
+    psutil: '>=5.8.0'
+    pyyaml: '>=5.4.1'
+    sortedcontainers: '>=2.0.5'
+    tblib: '>=1.6.0,<3.2.0 || >3.2.0,<3.2.1 || >3.2.1'
+    toolz: '>=0.12.0'
+    tornado: '>=6.2.0'
+    zict: '>=3.0.0'
+  url: https://files.pythonhosted.org/packages/b4/62/674ba5ada6de5615b458d768c0f0fb1a7b53299486fb38a36e0694f3c617/distributed-2026.6.0-py3-none-any.whl
+  hash:
+    sha256: ca034e8b4d05b8a92f0655ebd0914e82308509a213889456d7ddd2bd0543439b
+  category: notebooks
+  optional: true
+- name: distributed
+  version: 2026.6.0
+  manager: pip
+  platform: osx-64
+  dependencies:
+    click: '>=8.0'
+    cloudpickle: '>=3.0.0'
+    dask: '>=2026.6.0,<2026.6.1'
+    jinja2: '>=2.10.3'
+    locket: '>=1.0.0'
+    msgpack: '>=1.0.2'
+    packaging: '>=20.0'
+    psutil: '>=5.8.0'
+    pyyaml: '>=5.4.1'
+    sortedcontainers: '>=2.0.5'
+    tblib: '>=1.6.0,<3.2.0 || >3.2.0,<3.2.1 || >3.2.1'
+    toolz: '>=0.12.0'
+    tornado: '>=6.2.0'
+    zict: '>=3.0.0'
+  url: https://files.pythonhosted.org/packages/b4/62/674ba5ada6de5615b458d768c0f0fb1a7b53299486fb38a36e0694f3c617/distributed-2026.6.0-py3-none-any.whl
+  hash:
+    sha256: ca034e8b4d05b8a92f0655ebd0914e82308509a213889456d7ddd2bd0543439b
+  category: container
+  optional: true
+- name: distributed
+  version: 2026.6.0
+  manager: pip
+  platform: osx-64
+  dependencies:
+    click: '>=8.0'
+    cloudpickle: '>=3.0.0'
+    dask: '>=2026.6.0,<2026.6.1'
+    jinja2: '>=2.10.3'
+    locket: '>=1.0.0'
+    msgpack: '>=1.0.2'
+    packaging: '>=20.0'
+    psutil: '>=5.8.0'
+    pyyaml: '>=5.4.1'
+    sortedcontainers: '>=2.0.5'
+    tblib: '>=1.6.0,<3.2.0 || >3.2.0,<3.2.1 || >3.2.1'
+    toolz: '>=0.12.0'
+    tornado: '>=6.2.0'
+    zict: '>=3.0.0'
+  url: https://files.pythonhosted.org/packages/b4/62/674ba5ada6de5615b458d768c0f0fb1a7b53299486fb38a36e0694f3c617/distributed-2026.6.0-py3-none-any.whl
+  hash:
+    sha256: ca034e8b4d05b8a92f0655ebd0914e82308509a213889456d7ddd2bd0543439b
+  category: notebooks
+  optional: true
+- name: distributed
+  version: 2026.6.0
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    click: '>=8.0'
+    cloudpickle: '>=3.0.0'
+    dask: '>=2026.6.0,<2026.6.1'
+    jinja2: '>=2.10.3'
+    locket: '>=1.0.0'
+    msgpack: '>=1.0.2'
+    packaging: '>=20.0'
+    psutil: '>=5.8.0'
+    pyyaml: '>=5.4.1'
+    sortedcontainers: '>=2.0.5'
+    tblib: '>=1.6.0,<3.2.0 || >3.2.0,<3.2.1 || >3.2.1'
+    toolz: '>=0.12.0'
+    tornado: '>=6.2.0'
+    zict: '>=3.0.0'
+  url: https://files.pythonhosted.org/packages/b4/62/674ba5ada6de5615b458d768c0f0fb1a7b53299486fb38a36e0694f3c617/distributed-2026.6.0-py3-none-any.whl
+  hash:
+    sha256: ca034e8b4d05b8a92f0655ebd0914e82308509a213889456d7ddd2bd0543439b
+  category: container
+  optional: true
+- name: distributed
+  version: 2026.6.0
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    click: '>=8.0'
+    cloudpickle: '>=3.0.0'
+    dask: '>=2026.6.0,<2026.6.1'
+    jinja2: '>=2.10.3'
+    locket: '>=1.0.0'
+    msgpack: '>=1.0.2'
+    packaging: '>=20.0'
+    psutil: '>=5.8.0'
+    pyyaml: '>=5.4.1'
+    sortedcontainers: '>=2.0.5'
+    tblib: '>=1.6.0,<3.2.0 || >3.2.0,<3.2.1 || >3.2.1'
+    toolz: '>=0.12.0'
+    tornado: '>=6.2.0'
+    zict: '>=3.0.0'
+  url: https://files.pythonhosted.org/packages/b4/62/674ba5ada6de5615b458d768c0f0fb1a7b53299486fb38a36e0694f3c617/distributed-2026.6.0-py3-none-any.whl
+  hash:
+    sha256: ca034e8b4d05b8a92f0655ebd0914e82308509a213889456d7ddd2bd0543439b
+  category: notebooks
   optional: true
 - name: distro
   version: 1.9.0
@@ -47786,6 +39954,86 @@ package:
     sha256: 0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e
   category: tools
   optional: true
+- name: locket
+  version: 1.0.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+  hash:
+    sha256: b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3
+  category: container
+  optional: true
+- name: locket
+  version: 1.0.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+  hash:
+    sha256: b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3
+  category: notebooks
+  optional: true
+- name: locket
+  version: 1.0.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+  hash:
+    sha256: b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3
+  category: container
+  optional: true
+- name: locket
+  version: 1.0.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+  hash:
+    sha256: b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3
+  category: notebooks
+  optional: true
+- name: locket
+  version: 1.0.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+  hash:
+    sha256: b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3
+  category: container
+  optional: true
+- name: locket
+  version: 1.0.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+  hash:
+    sha256: b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3
+  category: notebooks
+  optional: true
+- name: locket
+  version: 1.0.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+  hash:
+    sha256: b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3
+  category: container
+  optional: true
+- name: locket
+  version: 1.0.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+  hash:
+    sha256: b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3
+  category: notebooks
+  optional: true
 - name: markdown
   version: 3.10.2
   manager: pip
@@ -48286,6 +40534,86 @@ package:
     sha256: 84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
   category: tools
   optional: true
+- name: msgpack
+  version: 1.2.1
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  hash:
+    sha256: 787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d
+  category: container
+  optional: true
+- name: msgpack
+  version: 1.2.1
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  hash:
+    sha256: 787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d
+  category: notebooks
+  optional: true
+- name: msgpack
+  version: 1.2.1
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+  hash:
+    sha256: f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc
+  category: container
+  optional: true
+- name: msgpack
+  version: 1.2.1
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+  hash:
+    sha256: f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc
+  category: notebooks
+  optional: true
+- name: msgpack
+  version: 1.2.1
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl
+  hash:
+    sha256: 0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064
+  category: container
+  optional: true
+- name: msgpack
+  version: 1.2.1
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl
+  hash:
+    sha256: 0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064
+  category: notebooks
+  optional: true
+- name: msgpack
+  version: 1.2.1
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl
+  hash:
+    sha256: 491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056
+  category: container
+  optional: true
+- name: msgpack
+  version: 1.2.1
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl
+  hash:
+    sha256: 491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056
+  category: notebooks
+  optional: true
 - name: multidict
   version: 6.7.1
   manager: pip
@@ -48669,6 +40997,86 @@ package:
   hash:
     sha256: 6457aaa33a5d474aca678b8ead9b3dc298e89c68e67012e73146ea6fd54babf1
   category: tools
+  optional: true
+- name: narwhals
+  version: 2.22.1
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl
+  hash:
+    sha256: 60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53
+  category: container
+  optional: true
+- name: narwhals
+  version: 2.22.1
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl
+  hash:
+    sha256: 60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53
+  category: notebooks
+  optional: true
+- name: narwhals
+  version: 2.22.1
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl
+  hash:
+    sha256: 60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53
+  category: container
+  optional: true
+- name: narwhals
+  version: 2.22.1
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl
+  hash:
+    sha256: 60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53
+  category: notebooks
+  optional: true
+- name: narwhals
+  version: 2.22.1
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl
+  hash:
+    sha256: 60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53
+  category: container
+  optional: true
+- name: narwhals
+  version: 2.22.1
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl
+  hash:
+    sha256: 60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53
+  category: notebooks
+  optional: true
+- name: narwhals
+  version: 2.22.1
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl
+  hash:
+    sha256: 60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53
+  category: container
+  optional: true
+- name: narwhals
+  version: 2.22.1
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl
+  hash:
+    sha256: 60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53
+  category: notebooks
   optional: true
 - name: nbdime
   version: 4.0.4
@@ -48950,6 +41358,54 @@ package:
     sha256: 4bab1b2d6141fe7b32ae71dac905666ece4f94936efbfb13d55bb7739a3a6021
   category: tools
   optional: true
+- name: pandas
+  version: 3.0.3
+  manager: pip
+  platform: linux-64
+  dependencies:
+    numpy: '>=1.26.0'
+    python-dateutil: '>=2.8.2'
+  url: https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+  hash:
+    sha256: a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a
+  category: notebooks
+  optional: true
+- name: pandas
+  version: 3.0.3
+  manager: pip
+  platform: linux-aarch64
+  dependencies:
+    numpy: '>=1.26.0'
+    python-dateutil: '>=2.8.2'
+  url: https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
+  hash:
+    sha256: d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8
+  category: notebooks
+  optional: true
+- name: pandas
+  version: 3.0.3
+  manager: pip
+  platform: osx-64
+  dependencies:
+    numpy: '>=1.26.0'
+    python-dateutil: '>=2.8.2'
+  url: https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl
+  hash:
+    sha256: 67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa
+  category: notebooks
+  optional: true
+- name: pandas
+  version: 3.0.3
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    numpy: '>=1.26.0'
+    python-dateutil: '>=2.8.2'
+  url: https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl
+  hash:
+    sha256: 39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7
+  category: notebooks
+  optional: true
 - name: panel
   version: 1.9.3
   manager: pip
@@ -49142,6 +41598,102 @@ package:
     sha256: 6cdc0869b3ade232fc6d01691223cf86c2bdb53a6d5ba67a33dba838d8b8cf4c
   category: notebooks
   optional: true
+- name: partd
+  version: 1.4.2
+  manager: pip
+  platform: linux-64
+  dependencies:
+    locket: '*'
+    toolz: '*'
+  url: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
+  hash:
+    sha256: 978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f
+  category: container
+  optional: true
+- name: partd
+  version: 1.4.2
+  manager: pip
+  platform: linux-64
+  dependencies:
+    locket: '*'
+    toolz: '*'
+  url: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
+  hash:
+    sha256: 978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f
+  category: notebooks
+  optional: true
+- name: partd
+  version: 1.4.2
+  manager: pip
+  platform: linux-aarch64
+  dependencies:
+    locket: '*'
+    toolz: '*'
+  url: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
+  hash:
+    sha256: 978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f
+  category: container
+  optional: true
+- name: partd
+  version: 1.4.2
+  manager: pip
+  platform: linux-aarch64
+  dependencies:
+    locket: '*'
+    toolz: '*'
+  url: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
+  hash:
+    sha256: 978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f
+  category: notebooks
+  optional: true
+- name: partd
+  version: 1.4.2
+  manager: pip
+  platform: osx-64
+  dependencies:
+    locket: '*'
+    toolz: '*'
+  url: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
+  hash:
+    sha256: 978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f
+  category: container
+  optional: true
+- name: partd
+  version: 1.4.2
+  manager: pip
+  platform: osx-64
+  dependencies:
+    locket: '*'
+    toolz: '*'
+  url: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
+  hash:
+    sha256: 978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f
+  category: notebooks
+  optional: true
+- name: partd
+  version: 1.4.2
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    locket: '*'
+    toolz: '*'
+  url: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
+  hash:
+    sha256: 978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f
+  category: container
+  optional: true
+- name: partd
+  version: 1.4.2
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    locket: '*'
+    toolz: '*'
+  url: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
+  hash:
+    sha256: 978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f
+  category: notebooks
+  optional: true
 - name: pathspec
   version: 1.1.1
   manager: pip
@@ -49221,6 +41773,86 @@ package:
   hash:
     sha256: a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189
   category: tools
+  optional: true
+- name: pillow
+  version: 12.2.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  hash:
+    sha256: eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3
+  category: container
+  optional: true
+- name: pillow
+  version: 12.2.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  hash:
+    sha256: eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3
+  category: notebooks
+  optional: true
+- name: pillow
+  version: 12.2.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+  hash:
+    sha256: 5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed
+  category: container
+  optional: true
+- name: pillow
+  version: 12.2.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+  hash:
+    sha256: 5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed
+  category: notebooks
+  optional: true
+- name: pillow
+  version: 12.2.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl
+  hash:
+    sha256: 5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795
+  category: container
+  optional: true
+- name: pillow
+  version: 12.2.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl
+  hash:
+    sha256: 5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795
+  category: notebooks
+  optional: true
+- name: pillow
+  version: 12.2.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl
+  hash:
+    sha256: 56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f
+  category: container
+  optional: true
+- name: pillow
+  version: 12.2.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl
+  hash:
+    sha256: 56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f
+  category: notebooks
   optional: true
 - name: pockets
   version: 0.9.1
@@ -51466,6 +44098,86 @@ package:
     sha256: 7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752
   category: tools
   optional: true
+- name: sortedcontainers
+  version: 2.4.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+  hash:
+    sha256: a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
+  category: container
+  optional: true
+- name: sortedcontainers
+  version: 2.4.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+  hash:
+    sha256: a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
+  category: notebooks
+  optional: true
+- name: sortedcontainers
+  version: 2.4.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+  hash:
+    sha256: a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
+  category: container
+  optional: true
+- name: sortedcontainers
+  version: 2.4.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+  hash:
+    sha256: a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
+  category: notebooks
+  optional: true
+- name: sortedcontainers
+  version: 2.4.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+  hash:
+    sha256: a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
+  category: container
+  optional: true
+- name: sortedcontainers
+  version: 2.4.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+  hash:
+    sha256: a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
+  category: notebooks
+  optional: true
+- name: sortedcontainers
+  version: 2.4.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+  hash:
+    sha256: a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
+  category: container
+  optional: true
+- name: sortedcontainers
+  version: 2.4.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+  hash:
+    sha256: a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
+  category: notebooks
+  optional: true
 - name: sphinx
   version: 7.4.7
   manager: pip
@@ -52430,6 +45142,86 @@ package:
     sha256: f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3
   category: tools
   optional: true
+- name: tblib
+  version: 3.2.2
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
+  hash:
+    sha256: 26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76
+  category: container
+  optional: true
+- name: tblib
+  version: 3.2.2
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
+  hash:
+    sha256: 26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76
+  category: notebooks
+  optional: true
+- name: tblib
+  version: 3.2.2
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
+  hash:
+    sha256: 26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76
+  category: container
+  optional: true
+- name: tblib
+  version: 3.2.2
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
+  hash:
+    sha256: 26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76
+  category: notebooks
+  optional: true
+- name: tblib
+  version: 3.2.2
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
+  hash:
+    sha256: 26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76
+  category: container
+  optional: true
+- name: tblib
+  version: 3.2.2
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
+  hash:
+    sha256: 26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76
+  category: notebooks
+  optional: true
+- name: tblib
+  version: 3.2.2
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
+  hash:
+    sha256: 26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76
+  category: container
+  optional: true
+- name: tblib
+  version: 3.2.2
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
+  hash:
+    sha256: 26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76
+  category: notebooks
+  optional: true
 - name: tenacity
   version: 9.1.4
   manager: pip
@@ -52552,6 +45344,86 @@ package:
   url: https://files.pythonhosted.org/packages/eb/0b/633691d7cea5129afa622869485d1985b038df1d3597a35848731d106762/tinynetrc-1.3.1-py2.py3-none-any.whl
   hash:
     sha256: 46c7820e5f49c9434d2c4cd74de8a06edbbd45e63a8a2980a90b8a43db8facf7
+  category: notebooks
+  optional: true
+- name: toolz
+  version: 1.1.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
+  hash:
+    sha256: 15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8
+  category: container
+  optional: true
+- name: toolz
+  version: 1.1.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
+  hash:
+    sha256: 15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8
+  category: notebooks
+  optional: true
+- name: toolz
+  version: 1.1.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
+  hash:
+    sha256: 15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8
+  category: container
+  optional: true
+- name: toolz
+  version: 1.1.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
+  hash:
+    sha256: 15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8
+  category: notebooks
+  optional: true
+- name: toolz
+  version: 1.1.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
+  hash:
+    sha256: 15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8
+  category: container
+  optional: true
+- name: toolz
+  version: 1.1.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
+  hash:
+    sha256: 15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8
+  category: notebooks
+  optional: true
+- name: toolz
+  version: 1.1.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
+  hash:
+    sha256: 15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8
+  category: container
+  optional: true
+- name: toolz
+  version: 1.1.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
+  hash:
+    sha256: 15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8
   category: notebooks
   optional: true
 - name: tqdm
@@ -53010,6 +45882,138 @@ package:
     sha256: e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617
   category: tools
   optional: true
+- name: xarray
+  version: 2026.4.0
+  manager: pip
+  platform: linux-64
+  dependencies:
+    numpy: '>=1.26'
+    packaging: '>=24.2'
+    pandas: '>=2.2'
+  url: https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl
+  hash:
+    sha256: d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08
+  category: notebooks
+  optional: true
+- name: xarray
+  version: 2026.4.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies:
+    numpy: '>=1.26'
+    packaging: '>=24.2'
+    pandas: '>=2.2'
+  url: https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl
+  hash:
+    sha256: d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08
+  category: notebooks
+  optional: true
+- name: xarray
+  version: 2026.4.0
+  manager: pip
+  platform: osx-64
+  dependencies:
+    numpy: '>=1.26'
+    packaging: '>=24.2'
+    pandas: '>=2.2'
+  url: https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl
+  hash:
+    sha256: d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08
+  category: notebooks
+  optional: true
+- name: xarray
+  version: 2026.4.0
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    numpy: '>=1.26'
+    packaging: '>=24.2'
+    pandas: '>=2.2'
+  url: https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl
+  hash:
+    sha256: d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08
+  category: notebooks
+  optional: true
+- name: xyzservices
+  version: 2026.3.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
+  hash:
+    sha256: 503183d4b322bfebc3c50cdd21192aa3e81e36c5efbf9133d54ae82143e0576b
+  category: container
+  optional: true
+- name: xyzservices
+  version: 2026.3.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
+  hash:
+    sha256: 503183d4b322bfebc3c50cdd21192aa3e81e36c5efbf9133d54ae82143e0576b
+  category: notebooks
+  optional: true
+- name: xyzservices
+  version: 2026.3.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
+  hash:
+    sha256: 503183d4b322bfebc3c50cdd21192aa3e81e36c5efbf9133d54ae82143e0576b
+  category: container
+  optional: true
+- name: xyzservices
+  version: 2026.3.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
+  hash:
+    sha256: 503183d4b322bfebc3c50cdd21192aa3e81e36c5efbf9133d54ae82143e0576b
+  category: notebooks
+  optional: true
+- name: xyzservices
+  version: 2026.3.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
+  hash:
+    sha256: 503183d4b322bfebc3c50cdd21192aa3e81e36c5efbf9133d54ae82143e0576b
+  category: container
+  optional: true
+- name: xyzservices
+  version: 2026.3.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
+  hash:
+    sha256: 503183d4b322bfebc3c50cdd21192aa3e81e36c5efbf9133d54ae82143e0576b
+  category: notebooks
+  optional: true
+- name: xyzservices
+  version: 2026.3.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
+  hash:
+    sha256: 503183d4b322bfebc3c50cdd21192aa3e81e36c5efbf9133d54ae82143e0576b
+  category: container
+  optional: true
+- name: xyzservices
+  version: 2026.3.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
+  hash:
+    sha256: 503183d4b322bfebc3c50cdd21192aa3e81e36c5efbf9133d54ae82143e0576b
+  category: notebooks
+  optional: true
 - name: yarl
   version: 1.24.2
   manager: pip
@@ -53209,4 +46213,84 @@ package:
   hash:
     sha256: aa3aa295257bebaa09ea9ad5cb288bf9f98f88de6932f96b6659f62715d83581
   category: tools
+  optional: true
+- name: zict
+  version: 3.0.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
+  hash:
+    sha256: 5796e36bd0e0cc8cf0fbc1ace6a68912611c1dbd74750a3f3026b9b9d6a327ae
+  category: container
+  optional: true
+- name: zict
+  version: 3.0.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
+  hash:
+    sha256: 5796e36bd0e0cc8cf0fbc1ace6a68912611c1dbd74750a3f3026b9b9d6a327ae
+  category: notebooks
+  optional: true
+- name: zict
+  version: 3.0.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
+  hash:
+    sha256: 5796e36bd0e0cc8cf0fbc1ace6a68912611c1dbd74750a3f3026b9b9d6a327ae
+  category: container
+  optional: true
+- name: zict
+  version: 3.0.0
+  manager: pip
+  platform: linux-aarch64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
+  hash:
+    sha256: 5796e36bd0e0cc8cf0fbc1ace6a68912611c1dbd74750a3f3026b9b9d6a327ae
+  category: notebooks
+  optional: true
+- name: zict
+  version: 3.0.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
+  hash:
+    sha256: 5796e36bd0e0cc8cf0fbc1ace6a68912611c1dbd74750a3f3026b9b9d6a327ae
+  category: container
+  optional: true
+- name: zict
+  version: 3.0.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
+  hash:
+    sha256: 5796e36bd0e0cc8cf0fbc1ace6a68912611c1dbd74750a3f3026b9b9d6a327ae
+  category: notebooks
+  optional: true
+- name: zict
+  version: 3.0.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
+  hash:
+    sha256: 5796e36bd0e0cc8cf0fbc1ace6a68912611c1dbd74750a3f3026b9b9d6a327ae
+  category: container
+  optional: true
+- name: zict
+  version: 3.0.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
+  hash:
+    sha256: 5796e36bd0e0cc8cf0fbc1ace6a68912611c1dbd74750a3f3026b9b9d6a327ae
+  category: notebooks
   optional: true

--- a/docs/notebooks/oci/oci_data_visualization_part2.md
+++ b/docs/notebooks/oci/oci_data_visualization_part2.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.18.1
+    jupytext_version: 1.19.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -255,24 +255,47 @@ margin = 1
 We need to first create a grid.
 
 ```{code-cell} ipython3
-grid_pro = pyinterp.backends.xarray.Grid2D(dataset_phy["prococcus_moana"])
-grid_syn = pyinterp.backends.xarray.Grid2D(dataset_phy["syncoccus_moana"])
-grid_pic = pyinterp.backends.xarray.Grid2D(dataset_phy["picoeuk_moana"])
+def fill_gaps_limited_pure_numpy(data, margin_pixels=1):
+    """
+    Fill gaps using only numpy.
+    """
+    result = data.copy()
+    
+    # Get array dimensions
+    rows, cols = data.shape
+    
+    # Find all NaN positions
+    nan_rows, nan_cols = np.where(np.isnan(data))
+    
+    for i, j in zip(nan_rows, nan_cols):
+        # Define search window around the NaN pixel
+        row_min = max(0, i - margin_pixels)
+        row_max = min(rows, i + margin_pixels + 1)
+        col_min = max(0, j - margin_pixels)
+        col_max = min(cols, j + margin_pixels + 1)
+        
+        # Extract the local window
+        window = data[row_min:row_max, col_min:col_max]
+        
+        # If there are valid values in the window, use the mean
+        valid_values = window[~np.isnan(window)]
+        if len(valid_values) > 0:
+            result[i, j] = np.mean(valid_values)
+    
+    return result
 ```
 
-Then interpolate the gridded data and transpose it back into its shape.
-
 ```{code-cell} ipython3
-pro = pyinterp.fill.loess(grid_pro, nx=margin, ny=margin)
-syn = pyinterp.fill.loess(grid_syn, nx=margin, ny=margin)
-pic = pyinterp.fill.loess(grid_pic, nx=margin, ny=margin)
-
-dataset_phy["prococcus_moana"][...] = pro.transpose()
-dataset_phy["syncoccus_moana"][...] = syn.transpose()
-dataset_phy["picoeuk_moana"][...] = pic.transpose()
+dataset_phy["prococcus_moana"][...] = fill_gaps_limited_pure_numpy(dataset_phy["prococcus_moana"].values, margin)
+dataset_phy["syncoccus_moana"][...] = fill_gaps_limited_pure_numpy(dataset_phy["syncoccus_moana"].values, margin)
+dataset_phy["picoeuk_moana"][...] = fill_gaps_limited_pure_numpy(dataset_phy["picoeuk_moana"].values, margin)
 ```
 
 If we have a look at the transect again, we can see that some of the values have been filled in by the interpolation.
+
+```{code-cell} ipython3
+dataset_phy
+```
 
 ```{code-cell} ipython3
 plot = dataset_phy["syncoccus_moana"].plot.imshow(robust="true")
@@ -289,17 +312,13 @@ margin_v = 1
 ```
 
 ```{code-cell} ipython3
-grid_cire = pyinterp.backends.xarray.Grid2D(dataset_veg["cire"])
-grid_car = pyinterp.backends.xarray.Grid2D(dataset_veg["car"])
-grid_mari = pyinterp.backends.xarray.Grid2D(dataset_veg["mari"])
+dataset_veg["cire"][...] = fill_gaps_limited_pure_numpy(dataset_veg["cire"].values, margin_v)
+dataset_veg["car"][...] = fill_gaps_limited_pure_numpy(dataset_veg["car"].values, margin_v)
+dataset_veg["mari"][...] = fill_gaps_limited_pure_numpy(dataset_veg["mari"].values, margin_v)
+```
 
-cir = pyinterp.fill.loess(grid_cire, nx=margin_v, ny=margin_v)
-car = pyinterp.fill.loess(grid_car, nx=margin_v, ny=margin_v)
-mar = pyinterp.fill.loess(grid_mari, nx=margin_v, ny=margin_v)
-
-dataset_veg["cire"][...] = cir.transpose()
-dataset_veg["car"][...] = car.transpose()
-dataset_veg["mari"][...] = mar.transpose()
+```{code-cell} ipython3
+plot = dataset_veg["car"].plot.imshow(robust="true")
 ```
 
 ### Normalize data
@@ -317,6 +336,8 @@ dataset_norm = (
 ```
 
 ```{code-cell} ipython3
+:scrolled: true
+
 dataset_v_norm = dataset_veg.astype(np.float64)
 dataset_v_norm = (
     (dataset_veg - dataset_veg.min())
@@ -609,6 +630,8 @@ else:
 Then we plot a rectangle around our area of interest on our RGB map. We can try to choose an area that is at the edge of a population to see the changes in time.
 
 ```{code-cell} ipython3
+:scrolled: true
+
 fig = plt.figure(figsize=(7, 7))
 ax1 = fig.add_subplot(projection=ccrs.PlateCarree(), facecolor="#080c17")
 ax2 = data_norm.plot.imshow(

--- a/docs/notebooks/oci/oci_data_visualization_part2.md
+++ b/docs/notebooks/oci/oci_data_visualization_part2.md
@@ -15,7 +15,7 @@ kernelspec:
 
 **Author(s):** Carina Poulin (NASA, SSAI). Edited from the PACE Data Visualization tutorial prepared for the PACE Hackweek 2025.
 
-Last updated: October 9, 2025
+Last updated: June 25, 2026
 
 <div class="alert alert-info" role="alert">
 
@@ -60,8 +60,6 @@ import h5netcdf
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import pyinterp.backends.xarray  # Module that handles the filling of undefined values.
-import pyinterp.fill
 import seaborn as sns
 import xarray as xr
 from matplotlib.patches import Rectangle
@@ -80,7 +78,7 @@ auth = earthaccess.login()
 For this example. we will be looking at a the month of July 2024.
 
 ```{code-cell} ipython3
-tspan = ("2024-07-01", "2024-07-30")
+tspan = ("2024-07", "2024-07")
 ```
 
 We look for two different types of products. The Multiple Ordination ANAlysis, or [MOANA][moana_atbd], is a new hyperspectral algorithm that measures the abundance of three different types of phytoplankton in the Atlantic Ocean. Only daily MOANA products are availabla from `earthaccess` for the moment.
@@ -92,6 +90,7 @@ results_moana = earthaccess.search_data(
     short_name="PACE_OCI_L4M_MOANA",
     granule_name="*.DAY.*0p1deg*",  # Daily only for MOANA | Resolution: 0p1deg or 4 (for 4km)
     temporal=tspan,
+    version="3.1",
 )
 ```
 
@@ -102,8 +101,8 @@ The second type of product we look for here is one of the new land products. Thi
 ```{code-cell} ipython3
 results_land = earthaccess.search_data(
     short_name="PACE_OCI_L3M_LANDVI",
-    temporal=tspan,
     granule_name="*.MO.*0p1deg*",  # Daily, 8-day or monthly: Day, 8D or MO | Resolution: 0p1deg or 0.4km
+    temporal=tspan,
 )
 ```
 
@@ -113,10 +112,14 @@ Here we will open the datasets.
 path_moana = earthaccess.open(results_moana)
 ```
 
-Since we are combining multiple files, we are using the `open_mfdataset` function and indicating that we want to concatenate the data by date.
+Since we are combining multiple files, we are using the `open_mfdataset` function and indicating that we want to concatenate the data by a new dimension called "date".
 
 ```{code-cell} ipython3
-dataset_moana = xr.open_mfdataset(path_moana, combine="nested", concat_dim="date")
+dataset_moana = xr.open_mfdataset(
+    path_moana,
+    combine="nested",
+    concat_dim="date",
+)
 dataset_moana
 ```
 
@@ -200,7 +203,7 @@ We will also remove the variables we will not be using for this example with `dr
 ```{code-cell} ipython3
 dataset_phy = dataset_moana.drop_vars(["palette"])
 dataset_veg = dataset_land.drop_vars(
-    ["palette", "ndvi", "evi", "ndwi", "ndii", "cci", "ndsi", "pri"]
+    ["palette", "ndvi", "evi", "ndwi", "ndii", "cci", "ndsi", "pri"],
 )
 ```
 
@@ -240,62 +243,23 @@ We can see there are some values missing, we can interpolate the data if we want
 
 ### MOANA (Optional)
 
-Here we offer the option of interpolating the data. This can be useful for filling gaps in the dataset, which can make visualizations smoother. Consider how it affects your statistics before using.
+Here we offer the option of interpolating the data. This can be useful for filling gaps in the dataset, which can make visualizations smoother. Consider how it affects your statistics before using for analysis.
 
 ```{code-cell} ipython3
 plot = dataset_phy["syncoccus_moana"].plot.imshow(robust="true")
 ```
 
-The `margin` parameter is the number of pixels on the X and Y axes to be considered in the calculation.
+A rolling average value, with parameters for the number of neighboring pixels on the `lon` and `lat` dimensions to use in the calculation and the minimum number of non-missing values to require, can fill in a lot of missing values.
 
 ```{code-cell} ipython3
-margin = 1
+for name, dataarray in dataset_phy.items():
+    dataset_phy[name] = dataarray.where(
+        dataarray.notnull(),
+        dataarray.rolling({"lat": 3, "lon": 3}, min_periods=1, center=True).mean(),
+    )
 ```
 
-We need to first create a grid.
-
-```{code-cell} ipython3
-def fill_gaps_limited_pure_numpy(data, margin_pixels=1):
-    """
-    Fill gaps using only numpy.
-    """
-    result = data.copy()
-    
-    # Get array dimensions
-    rows, cols = data.shape
-    
-    # Find all NaN positions
-    nan_rows, nan_cols = np.where(np.isnan(data))
-    
-    for i, j in zip(nan_rows, nan_cols):
-        # Define search window around the NaN pixel
-        row_min = max(0, i - margin_pixels)
-        row_max = min(rows, i + margin_pixels + 1)
-        col_min = max(0, j - margin_pixels)
-        col_max = min(cols, j + margin_pixels + 1)
-        
-        # Extract the local window
-        window = data[row_min:row_max, col_min:col_max]
-        
-        # If there are valid values in the window, use the mean
-        valid_values = window[~np.isnan(window)]
-        if len(valid_values) > 0:
-            result[i, j] = np.mean(valid_values)
-    
-    return result
-```
-
-```{code-cell} ipython3
-dataset_phy["prococcus_moana"][...] = fill_gaps_limited_pure_numpy(dataset_phy["prococcus_moana"].values, margin)
-dataset_phy["syncoccus_moana"][...] = fill_gaps_limited_pure_numpy(dataset_phy["syncoccus_moana"].values, margin)
-dataset_phy["picoeuk_moana"][...] = fill_gaps_limited_pure_numpy(dataset_phy["picoeuk_moana"].values, margin)
-```
-
-If we have a look at the transect again, we can see that some of the values have been filled in by the interpolation.
-
-```{code-cell} ipython3
-dataset_phy
-```
+If we have a look at the map again, we can see that some of the values have been filled in by the interpolation.
 
 ```{code-cell} ipython3
 plot = dataset_phy["syncoccus_moana"].plot.imshow(robust="true")
@@ -308,13 +272,11 @@ plot = dataset_phy["syncoccus_moana"].plot.imshow(robust="true")
 We separated the land and MOANA interpolations to allow you to choose different interpolations for each.
 
 ```{code-cell} ipython3
-margin_v = 1
-```
-
-```{code-cell} ipython3
-dataset_veg["cire"][...] = fill_gaps_limited_pure_numpy(dataset_veg["cire"].values, margin_v)
-dataset_veg["car"][...] = fill_gaps_limited_pure_numpy(dataset_veg["car"].values, margin_v)
-dataset_veg["mari"][...] = fill_gaps_limited_pure_numpy(dataset_veg["mari"].values, margin_v)
+for name, dataarray in dataset_veg.items():
+    dataset_veg[name] = dataarray.where(
+        dataarray.notnull(),
+        dataarray.rolling({"lat": 3, "lon": 3}, min_periods=1, center=True).mean(),
+    )
 ```
 
 ```{code-cell} ipython3
@@ -367,8 +329,8 @@ This is an example of how to show multiple variables from two different datasets
 
 ```{code-cell} ipython3
 fig = plt.figure(figsize=(6, 6))
-ax1 = fig.add_subplot(projection=ccrs.Orthographic(-30, 0), facecolor="#080c17")
-ax1.add_feature(
+ax = fig.add_subplot(projection=ccrs.Orthographic(-30, 0), facecolor="#080c17")
+ax.add_feature(
     cfeature.NaturalEarthFeature(
         "physical",
         "ocean",
@@ -379,7 +341,7 @@ ax1.add_feature(
     alpha=1,
     zorder=1,
 )
-ax1.add_feature(
+ax.add_feature(
     cfeature.NaturalEarthFeature(
         "physical",
         "land",
@@ -391,11 +353,11 @@ ax1.add_feature(
     zorder=2,
 )
 
-ax2 = data_norm.plot.imshow(
-    transform=ccrs.PlateCarree(), interpolation="none", zorder=3
+data_norm.plot.imshow(
+    ax=ax, transform=ccrs.PlateCarree(), interpolation="none", zorder=3
 )
-ax3 = data_norm_v.plot.imshow(
-    transform=ccrs.PlateCarree(), interpolation="none", zorder=4
+data_norm_v.plot.imshow(
+    ax=ax, transform=ccrs.PlateCarree(), interpolation="none", zorder=4
 )
 
 fig.patch.set_alpha(0.0)
@@ -439,7 +401,6 @@ plt.text(-0.8, 0.75, "mari", ha="center", va="center", fontsize=9)
 plt.text(0.8, 0.9, "Picoeukaryotes/", ha="center", va="center", fontsize=9)
 plt.text(0.8, 0.75, "cire", ha="center", va="center", fontsize=9)
 
-
 plt.axis("off")
 plt.tight_layout()
 plt.show()
@@ -450,9 +411,10 @@ If we want more geographical information on our map, we can add grids, coastline
 ```{code-cell} ipython3
 fig = plt.figure(figsize=(5, 5))
 extent = [-84, -30, 10, 60]
-ax1 = fig.add_subplot(projection=ccrs.PlateCarree(), facecolor="#080c17")
-ax1.gridlines(
-    crs=ccrs.PlateCarree(),
+crs = ccrs.PlateCarree()
+ax = fig.add_subplot(projection=crs, facecolor="#080c17")
+ax.gridlines(
+    crs=crs,
     draw_labels=True,
     linewidth=0.5,
     color="gray",
@@ -460,9 +422,8 @@ ax1.gridlines(
     linestyle="--",
     zorder=4,
 )
-ax1.coastlines(linewidth=0.4, color="black", zorder=3)
-
-ax1.add_feature(
+ax.coastlines(linewidth=0.4, color="black", zorder=3)
+ax.add_feature(
     cfeature.NaturalEarthFeature(
         "physical",
         "ocean",
@@ -473,15 +434,11 @@ ax1.add_feature(
     alpha=1,
     zorder=0,
 )
-# ax1.add_feature(cfeature.NaturalEarthFeature('physical', 'land', '110m', edgecolor='face', facecolor='#131c36'), alpha=0.85, zorder=5)
-ax1.set_extent(extent, crs=ccrs.PlateCarree())
+# ax.add_feature(cfeature.NaturalEarthFeature('physical', 'land', '110m', edgecolor='face', facecolor='#131c36'), alpha=0.85, zorder=5)
+ax.set_extent(extent, crs=crs)
 
-ax2 = data_norm.plot.imshow(
-    transform=ccrs.PlateCarree(), interpolation="none", zorder=1.5
-)
-ax3 = data_norm_v.plot.imshow(
-    transform=ccrs.PlateCarree(), interpolation="none", zorder=1
-)
+data_norm.plot.imshow(ax=ax, interpolation="none", zorder=1.5)
+data_norm_v.plot.imshow(ax=ax, interpolation="none", zorder=1)
 
 plt.show()
 ```
@@ -497,7 +454,7 @@ We are going to use what we just learned to create a timeline for a chosen area.
 ### Get data
 
 ```{code-cell} ipython3
-tspan = ("2024-04-01", "2025-03-31")
+tspan = ("2024-04", "2025-03")
 ```
 
 ```{code-cell} ipython3
@@ -505,6 +462,7 @@ results_moana = earthaccess.search_data(
     short_name="PACE_OCI_L4M_MOANA",
     granule_name="*.Day.*0p1deg*",  # Daily: Day | Resolution: 0p1deg or 4 (for 4km)
     temporal=tspan,
+    version="3.1",
 )
 ```
 
@@ -630,16 +588,13 @@ else:
 Then we plot a rectangle around our area of interest on our RGB map. We can try to choose an area that is at the edge of a population to see the changes in time.
 
 ```{code-cell} ipython3
-:scrolled: true
-
 fig = plt.figure(figsize=(7, 7))
-ax1 = fig.add_subplot(projection=ccrs.PlateCarree(), facecolor="#080c17")
-ax2 = data_norm.plot.imshow(
-    transform=ccrs.PlateCarree(), interpolation="none", zorder=3
-)
+ax = fig.add_subplot(projection=ccrs.PlateCarree(), facecolor="#080c17")
+
+data_norm.plot.imshow(ax=ax, interpolation="none", zorder=3)
 
 # Add bounding box
-ax1.add_patch(
+ax.add_patch(
     Rectangle(
         (lon_min, lat_min),
         lon_max - lon_min,
@@ -647,7 +602,6 @@ ax1.add_patch(
         edgecolor="red",
         facecolor="none",
         linewidth=1.5,
-        transform=ccrs.PlateCarree(),
         zorder=4,
     )
 )
@@ -682,7 +636,8 @@ We can now plot our timeline. We are going to plot the standard deviations as a 
 In this case, we also are drawing a second y axis with `twinx` for prochlorococcus, which has much higher concentrations than synechococcus and picoeukaryotes.
 
 ```{code-cell} ipython3
-fig, ax1 = plt.subplots(figsize=(10, 5))
+fig, ax_left = plt.subplots(figsize=(10, 5))
+ax_right = ax_left.twinx()
 
 # Style
 linewidth = 1
@@ -691,67 +646,40 @@ marker = "o"
 sns.set_style("white")
 palette = sns.color_palette("husl", 3)
 
-# Left y-axis plots
-ax1.plot(
-    region_mean["syncoccus_moana"].date,
-    region_mean["syncoccus_moana"],
-    color=palette[0],
-    marker=marker,
-    label="Syn",
-    linewidth=linewidth,
-    markersize=markersize,
-)
-ax1.fill_between(
-    region_mean["syncoccus_moana"].date,
-    region_mean["syncoccus_moana"] - region_std["syncoccus_moana"],
-    region_mean["syncoccus_moana"] + region_std["syncoccus_moana"],
-    color=palette[0],
-    alpha=0.2,
-)
+for i, var in enumerate(("syncoccus_moana", "picoeuk_moana", "prococcus_moana")):
+    
+    if var == "prococcus_moana":
+        ax = ax_right
+        linestyle = "--"
+    else:
+        ax = ax_left
+        linestyle = "-"
 
-ax1.plot(
-    region_mean["picoeuk_moana"].date,
-    region_mean["picoeuk_moana"],
-    color=palette[1],
-    marker=marker,
-    label="Pico",
-    linewidth=linewidth,
-    markersize=markersize,
-)
-ax1.fill_between(
-    region_mean["picoeuk_moana"].date,
-    region_mean["picoeuk_moana"] - region_std["picoeuk_moana"],
-    region_mean["picoeuk_moana"] + region_std["picoeuk_moana"],
-    color=palette[1],
-    alpha=0.2,
-)
+    ax.plot(
+        region_mean[var]["date"],
+        region_mean[var],
+        color=palette[i],
+        label=var.split("_")[0],
+        marker=marker,
+        linestyle=linestyle,
+        linewidth=linewidth,
+        markersize=markersize,
+    )
+    ax.fill_between(
+        region_mean[var]["date"],
+        region_mean[var] - region_std[var],
+        region_mean[var] + region_std[var],
+        color=palette[i],
+        alpha=0.2,
+    )
 
-# Right y-axis plot
-ax2 = ax1.twinx()
-ax2.plot(
-    region_mean["prococcus_moana"].date,
-    region_mean["prococcus_moana"],
-    color=palette[2],
-    marker=marker,
-    linestyle="--",
-    label="Pro",
-    linewidth=linewidth,
-    markersize=markersize,
-)
-ax2.fill_between(
-    region_mean["prococcus_moana"].date,
-    region_mean["prococcus_moana"] - region_std["prococcus_moana"],
-    region_mean["prococcus_moana"] + region_std["prococcus_moana"],
-    color=palette[2],
-    alpha=0.2,
-)
+# Formatting
+ax_left.set_ylabel("Synechococcus and Picoeukaryotes (cells/ml)")
+ax_left.legend(loc="upper left")
+ax_left.set_xlabel("Date")
 
-ax1.legend(loc="upper left")
-ax2.legend(loc="upper right")
-
-ax1.set_ylabel("Synechococcus and Picoeukaryotes (cells/ml)")
-ax2.set_ylabel("Prochlorococcus (cells/ml)")
-ax1.set_xlabel("Date")
+ax_right.set_ylabel("Prochlorococcus (cells/ml)")
+ax_right.legend(loc="upper right")
 
 plt.title("MOANA Phytoplankton Timeline")
 plt.tight_layout()
@@ -770,87 +698,60 @@ monthly_stds = region_std.resample(date='MS').mean()
 ```
 
 ```{code-cell} ipython3
-monthly_stds.load()
 monthly_means.load()
+monthly_stds.load()
 ```
 
 We can now plot our monthly averages.
 
 ```{code-cell} ipython3
-fig, ax1 = plt.subplots(figsize=(12, 5))
+fig, ax_left = plt.subplots(figsize=(10, 5))
+ax_right = ax_left.twinx()
 
 # Style
 linewidth = 1
-markersize = 5
+markersize = 2
+marker = "o"
 sns.set_style("white")
 palette = sns.color_palette("husl", 3)
 
-dates = monthly_means['date']
+for i, var in enumerate(("syncoccus_moana", "picoeuk_moana", "prococcus_moana")):
+    
+    if var == "prococcus_moana":
+        ax = ax_right
+        linestyle = "--"
+    else:
+        ax = ax_left
+        linestyle = "-"
 
-# Left axis
-ax1.plot(
-    dates,
-    monthly_means["syncoccus_moana"].values,
-    "o-",
-    color=palette[0],
-    label="Synechococcus",
-    linewidth=linewidth,
-    markersize=markersize,
-)
-ax1.fill_between(
-    dates,
-    monthly_means["syncoccus_moana"] - monthly_stds["syncoccus_moana"],
-    monthly_means["syncoccus_moana"] + monthly_stds["syncoccus_moana"],
-    color=palette[0],
-    alpha=0.2,
-)
-
-ax1.plot(
-    dates,
-    monthly_means["picoeuk_moana"].values,
-    "s-",
-    color=palette[1],
-    label="Picoeukaryotes",
-    linewidth=linewidth,
-    markersize=markersize,
-)
-ax1.fill_between(
-    dates,
-    monthly_means["picoeuk_moana"] - monthly_stds["picoeuk_moana"],
-    monthly_means["picoeuk_moana"] + monthly_stds["picoeuk_moana"],
-    color=palette[1],
-    alpha=0.2,
-)
-
-# Second y-axis
-ax2 = ax1.twinx()
-ax2.plot(
-    dates,
-    monthly_means["prococcus_moana"].values,
-    "^--",
-    color=palette[2],
-    label="Prochlorococcus",
-    linewidth=linewidth,
-    markersize=markersize,
-)
-ax2.fill_between(
-    dates,
-    monthly_means["prococcus_moana"] - monthly_stds["prococcus_moana"],
-    monthly_means["prococcus_moana"] + monthly_stds["prococcus_moana"],
-    color=palette[2],
-    alpha=0.2,
-)
+    ax.plot(
+        monthly_means[var]["date"],
+        monthly_means[var],
+        color=palette[i],
+        label=var.split("_")[0],
+        marker=marker,
+        linestyle=linestyle,
+        linewidth=linewidth,
+        markersize=markersize,
+    )
+    ax.fill_between(
+        monthly_means[var]["date"],
+        monthly_means[var] - monthly_stds[var],
+        monthly_means[var] + monthly_stds[var],
+        color=palette[i],
+        alpha=0.2,
+    )
 
 # Formatting
-ax1.set_xlabel("Date", fontsize=12)
-ax1.set_ylabel("Synechococcus and Picoeukaryotes (cells/ml)", fontsize=12)
-ax2.set_ylabel("Prochlorococcus (cells/ml)", fontsize=12)
+ax_left.set_ylabel("Synechococcus and Picoeukaryotes (cells/ml)", fontsize=12)
+ax_left.legend(loc="upper left", frameon=True, framealpha=0.6)
+ax_left.set_xlabel("Date", fontsize=12)
+
+ax_right.set_ylabel("Prochlorococcus (cells/ml)", fontsize=12)
+ax_right.legend(loc="upper right", frameon=True, framealpha=0.6)
 
 # Rotate x-axis labels for better readability
-plt.setp(ax1.get_xticklabels(), rotation=45, ha="right")
-
-ax1.legend(loc="upper left", frameon=True, framealpha=0.6)
-ax2.legend(loc="upper right", frameon=True, framealpha=0.6)
+plt.setp(ax_left.get_xticklabels(), rotation=45, ha="right")
 
 plt.title("Monthly Averages for Region", fontsize=14)
 plt.tight_layout()

--- a/environment-notebooks.yml
+++ b/environment-notebooks.yml
@@ -3,7 +3,6 @@ channels:
 dependencies:
   - libgdal-core>=3.10.3
   - netcdf4>=1.6.5
-  - pyinterp>=2024.11.0
   - pytorch>=2.8.0
   - numba>=0.65.1
 category: notebooks


### PR DESCRIPTION
- replaces the pyinterp functionality with rolling averages, since pyinterp code was no longer working in the latest environment
- removes pyinterp from the container image
- **pins MOANA to 3.1 because of issues with 3.2 over land**
- eliminates code redundancy in some plotting sections