### PR TITLE
docs: list recent Ocean tutorials

### DIFF
--- a/docs/sections/ocean.md
+++ b/docs/sections/ocean.md
@@ -6,7 +6,7 @@ This section focuses on ocean color data products and marine applications from P
 
 - [GPig Phytoplankton Community Composition](../notebooks/oci/oci_gpig) - Analyzing phytoplankton community structure using PACE/OCI data with the GPig algorithm
 - [Spectral Derivative Pigments (SDP)](../notebooks/oci/oci_sdp) - Estimating phytoplankton pigment concentrations from PACE/OCI Level-2 data with the SDP algorithm
-- [Multi Ordination ANAlysis (MOANA)](../notebooks/oci/oci_moana) - Accessing and visualizing picophytoplankton community composition products from PACE/OCI
-- [Access the CLOSE Dataset](../notebooks/oci/accessing_CLOSE_data) - Discovering, accessing, and comparing simulated PACE ocean data products with `earthaccess` and `xarray`
+- [Multi Ordination ANAlysis (MOANA)](../notebooks/oci/oci_moana) - Accessing and visualizing the first picophytoplankton community composition product from PACE/OCI
+- [Access the CLOSE Dataset](../notebooks/oci/accessing_CLOSE_data) - Explore the simulated dataset supporting algorithm development for PACE ocean data products
 
 Browse the tutorials above to get started with ocean color analysis and phytoplankton community composition studies.

--- a/docs/sections/ocean.md
+++ b/docs/sections/ocean.md
@@ -5,5 +5,8 @@ This section focuses on ocean color data products and marine applications from P
 **What you'll learn:**
 
 - [GPig Phytoplankton Community Composition](../notebooks/oci/oci_gpig) - Analyzing phytoplankton community structure using PACE/OCI data with the GPig algorithm
+- [Spectral Derivative Pigments (SDP)](../notebooks/oci/oci_sdp) - Estimating phytoplankton pigment concentrations from PACE/OCI Level-2 data with the SDP algorithm
+- [Multi Ordination ANAlysis (MOANA)](../notebooks/oci/oci_moana) - Accessing and visualizing picophytoplankton community composition products from PACE/OCI
+- [Access the CLOSE Dataset](../notebooks/oci/accessing_CLOSE_data) - Discovering, accessing, and comparing simulated PACE ocean data products with `earthaccess` and `xarray`
 
-Browse the tutorial above to get started with ocean color analysis for phytoplankton community composition studies.
+Browse the tutorials above to get started with ocean color analysis and phytoplankton community composition studies.


### PR DESCRIPTION
## Summary

- add the SDP, MOANA, and CLOSE tutorials to the Ocean section landing page
- describe each tutorial using its documented learning objectives
- update the closing copy to refer to multiple tutorials

## Why

These notebooks were already included in the Jupyter Book table of contents, but the Ocean landing page still listed only GPig. This left users without direct section-page links or descriptions for the three newer tutorials.

## Validation

- `pre-commit run --files docs/sections/ocean.md`
- full 42-page Jupyter Book HTML build with warnings treated as errors and notebook execution disabled; all new internal links resolved
- `git diff --check`

Closes #185.
